### PR TITLE
Improve settings links and modal tab handling

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -239,6 +239,9 @@ const Sidebar: React.FC<SidebarProps> = ({ onSelect, apps }) => {
 						showGlobalForm={showGlobalForm}
 						starterScale={starterScale}
 						updateAgent={updateAgent}
+						onOpenAgentSettings={() => openConfigModal("agent")}
+						onOpenGlobalSettings={() => openConfigModal("global")}
+						onOpenUserSettings={() => openConfigModal("user")}
 					/>
 
 					{conv.loading && (

--- a/components/Sidebar/ApplicationsStarter.tsx
+++ b/components/Sidebar/ApplicationsStarter.tsx
@@ -28,6 +28,9 @@ export default function ApplicationsStarter(props: {
 	showGlobalForm: boolean;
 	setShowGlobalForm: (fn: (v: boolean) => boolean) => void;
 	apps?: AppOption[];
+	onOpenAgentSettings?: () => void;
+	onOpenGlobalSettings?: () => void;
+	onOpenUserSettings?: () => void;
 }) {
 	const {
 		collapsedStarter,
@@ -42,6 +45,9 @@ export default function ApplicationsStarter(props: {
 		showGlobalForm,
 		setShowGlobalForm,
 		apps,
+		onOpenAgentSettings,
+		onOpenGlobalSettings,
+		onOpenUserSettings,
 	} = props;
 
 	const starterApps: AppOption[] = useMemo(
@@ -98,8 +104,19 @@ export default function ApplicationsStarter(props: {
 
 					{/* Inline Agent Controls */}
 					<div className="px-2 py-2 space-y-2 text-xs group-data-[state=collapsed]/sidebar:hidden">
-						<div className="font-medium text-muted-foreground">
-							Agent quick settings
+						<div className="flex items-center justify-between gap-2">
+							<span className="font-medium text-muted-foreground">
+								Agent quick settings
+							</span>
+							{onOpenAgentSettings && (
+								<button
+									className="text-[11px] font-medium text-primary hover:underline"
+									type="button"
+									onClick={onOpenAgentSettings}
+								>
+									Open full agent settings
+								</button>
+							)}
 						</div>
 						<div className="grid grid-cols-1 gap-2">
 							{/* Language */}
@@ -196,29 +213,48 @@ export default function ApplicationsStarter(props: {
 								/>
 							</div>
 						</div>
+						{onOpenUserSettings && (
+							<button
+								className="text-[11px] font-medium text-primary hover:underline"
+								type="button"
+								onClick={onOpenUserSettings}
+							>
+								View user settings
+							</button>
+						)}
 					</div>
 
 					{/* Inline Global Settings */}
 					<div className="px-2 py-2 space-y-2 text-xs group-data-[state=collapsed]/sidebar:hidden">
-						<button
-							className="flex w-full items-center justify-between rounded-md px-2 py-1 text-left hover:bg-muted"
-							type="button"
-							onClick={() => setShowGlobalForm((v) => !v)}
-						>
-							<span className="font-medium text-muted-foreground">
-								Global settings
-							</span>
-							<ChevronRight
-								className={`size-3 transition-transform ${showGlobalForm ? "rotate-90" : "rotate-0"}`}
-							/>
-						</button>
+						<div className="flex items-center justify-between gap-2">
+							<button
+								className="flex w-full flex-1 items-center justify-between rounded-md px-2 py-1 text-left hover:bg-muted"
+								type="button"
+								onClick={() => setShowGlobalForm((v) => !v)}
+							>
+								<span className="font-medium text-muted-foreground">
+									Global settings
+								</span>
+								<ChevronRight
+									className={`size-3 transition-transform ${showGlobalForm ? "rotate-90" : "rotate-0"}`}
+								/>
+							</button>
+							{onOpenGlobalSettings && (
+								<button
+									className="text-[11px] font-medium text-primary hover:underline"
+									type="button"
+									onClick={onOpenGlobalSettings}
+								>
+									Open full
+								</button>
+							)}
+						</div>
 						{showGlobalForm && (
 							<div className="grid grid-cols-1 gap-2">
 								{(() => {
 									const defaults = {
 										theme: "system",
 										telemetryEnabled: false,
-										apiBaseUrl: "https://api.heygen.com",
 									} as const;
 									const gs = globalSettings ?? (defaults as any);
 
@@ -258,24 +294,6 @@ export default function ApplicationsStarter(props: {
 														setGlobalSettings({
 															...(gs as any),
 															telemetryEnabled: e.target.checked,
-														})
-													}
-												/>
-											</label>
-
-											{/* API Base URL */}
-											<label className="grid gap-1">
-												<span className="text-[10px] uppercase tracking-wide text-muted-foreground">
-													API Base URL
-												</span>
-												<input
-													className="h-8 rounded-md border border-border bg-background px-2 text-sm"
-													placeholder="https://api.heygen.com"
-													value={(gs as any).apiBaseUrl ?? ""}
-													onChange={(e) =>
-														setGlobalSettings({
-															...(gs as any),
-															apiBaseUrl: e.target.value,
 														})
 													}
 												/>

--- a/components/Sidebar/CollapsedEdgeTrigger.tsx
+++ b/components/Sidebar/CollapsedEdgeTrigger.tsx
@@ -26,7 +26,7 @@ export default function CollapsedEdgeTrigger() {
 				aria-label="Avatar settings"
 				className="size-9 inline-flex items-center justify-center rounded-full border border-primary/40 bg-primary/10 text-primary shadow-md hover:bg-primary/15 backdrop-blur supports-[backdrop-filter]:bg-primary/10"
 				variant="ghost"
-				onClick={openConfigModal}
+				onClick={() => openConfigModal()}
 			>
 				<Settings className="size-5" />
 			</Button>

--- a/components/Sidebar/HeaderActionsStack.tsx
+++ b/components/Sidebar/HeaderActionsStack.tsx
@@ -72,7 +72,7 @@ export default function HeaderActionsStack({
 				aria-label="Avatar settings"
 				className="size-8 text-foreground hover:bg-muted"
 				variant="ghost"
-				onClick={openConfigModal}
+				onClick={() => openConfigModal()}
 			>
 				<Settings className="size-4" />
 			</Button>

--- a/components/modals/session/GlobalSettingsTab.tsx
+++ b/components/modals/session/GlobalSettingsTab.tsx
@@ -18,8 +18,8 @@ export function GlobalSettingsTab({
 	return (
 		<div className="space-y-4 rounded-xl border border-border bg-card p-4 md:p-6 shadow-sm">
 			<p className="text-sm text-muted-foreground">
-				Configure app-wide options (theme, telemetry, API base URL). These
-				persist locally in your browser.
+				Configure app-wide options (theme and telemetry). These persist locally
+				in your browser.
 			</p>
 			<AutoForm
 				className="space-y-3"

--- a/components/modals/session/Tabs.tsx
+++ b/components/modals/session/Tabs.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-export type TabKey = "session" | "global" | "user" | "agent";
+import type { ConfigModalTab } from "@/lib/stores/session";
+
+export type TabKey = ConfigModalTab;
 
 interface TabsHeaderProps {
 	activeTab: TabKey;

--- a/components/ui/SessionConfigModal.tsx
+++ b/components/ui/SessionConfigModal.tsx
@@ -1,5 +1,6 @@
 import type { StartAvatarRequest } from "@heygen/streaming-avatar";
 import type { UserSettings, AppGlobalSettings } from "@/lib/schemas/global";
+import type { ConfigModalTab } from "@/lib/stores/session";
 
 import { useEffect, useRef, useState } from "react";
 import { z } from "zod";
@@ -43,17 +44,20 @@ export function SessionConfigModal({
 	initialConfig,
 	startSession,
 }: SessionConfigModalProps) {
-	const { isConfigModalOpen, closeConfigModal, agentSettings } =
-		useSessionStore();
+	const {
+		isConfigModalOpen,
+		closeConfigModal,
+		agentSettings,
+		configModalTab,
+		setConfigModalTab,
+	} = useSessionStore();
 	const { userSettings, setUserSettings, globalSettings, setGlobalSettings } =
 		useSettingsStore();
 	const setThemeMode = useThemeStore((s) => s.setMode);
 	const { currentAgent, setAgent, updateAgent, setLastStarted, markClean } =
 		useAgentStore();
 	const [config, setConfig] = useState<StartAvatarRequest>(initialConfig);
-	const [activeTab, setActiveTab] = useState<
-		"session" | "global" | "user" | "agent"
-	>("session");
+	const [activeTab, setActiveTab] = useState<ConfigModalTab>(configModalTab);
 	const [isPublishOpen, setPublishOpen] = useState(false);
 	const {
 		avatarOptions,
@@ -65,6 +69,10 @@ export function SessionConfigModal({
 	useEffect(() => {
 		setConfig(initialConfig);
 	}, [initialConfig]);
+
+	useEffect(() => {
+		setActiveTab(configModalTab);
+	}, [configModalTab]);
 
 	// Prefill/merge settings into session config whenever user settings change
 	useEffect(() => {
@@ -98,6 +106,11 @@ export function SessionConfigModal({
 		closeConfigModal();
 	};
 
+	const handleTabChange = (tab: ConfigModalTab) => {
+		setActiveTab(tab);
+		setConfigModalTab(tab);
+	};
+
 	// User Settings form instance
 	const userForm = useZodForm(UserSettingsSchema, {
 		defaultValues: {
@@ -113,7 +126,6 @@ export function SessionConfigModal({
 		defaultValues: {
 			theme: "system",
 			telemetryEnabled: false,
-			apiBaseUrl: "https://api.heygen.com",
 		} as Partial<AppGlobalSettings>,
 		mode: "onChange",
 	});
@@ -214,12 +226,17 @@ export function SessionConfigModal({
 	]);
 
 	return (
-		<Dialog open={isConfigModalOpen} onOpenChange={closeConfigModal}>
+		<Dialog
+			open={isConfigModalOpen}
+			onOpenChange={(open) => {
+				if (!open) closeConfigModal();
+			}}
+		>
 			<DialogContent className="w-[96vw] md:w-[92vw] max-w-[1280px] p-0 bg-card text-foreground flex flex-col max-h-[90vh]">
 				<SessionConfigHeader />
 
 				{/* Tabs Header */}
-				<TabsHeader activeTab={activeTab} setActiveTab={setActiveTab} />
+				<TabsHeader activeTab={activeTab} setActiveTab={handleTabChange} />
 
 				{/* Tabs Content */}
 				<div className="flex-1 overflow-y-auto p-4 md:p-6">

--- a/lib/schemas/global.ts
+++ b/lib/schemas/global.ts
@@ -21,7 +21,6 @@ export type UserSettings = z.infer<typeof UserSettingsSchema>;
 export const AppGlobalSettingsSchema = z.object({
 	theme: z.enum(["system", "dark", "light"]).default("system"),
 	telemetryEnabled: z.boolean().default(false),
-	apiBaseUrl: z.string().url().default("https://api.heygen.com"),
 });
 
 export type AppGlobalSettings = z.infer<typeof AppGlobalSettingsSchema>;

--- a/lib/stores/_tests/sessionStore.test.ts
+++ b/lib/stores/_tests/sessionStore.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useSessionStore, type ConfigModalTab } from "../session";
+
+describe("useSessionStore config modal controls", () => {
+	beforeEach(() => {
+		const { persist } = useSessionStore.getState() as unknown as {
+			persist?: { clearStorage: () => void };
+		};
+		persist?.clearStorage?.();
+		useSessionStore.setState((state) => ({
+			...state,
+			isConfigModalOpen: false,
+			configModalTab: "session",
+		}));
+	});
+
+	it("opens the modal on the requested tab", () => {
+		useSessionStore.getState().openConfigModal("agent");
+
+		const state = useSessionStore.getState();
+		expect(state.isConfigModalOpen).toBe(true);
+		expect(state.configModalTab).toBe<ConfigModalTab>("agent");
+	});
+
+	it("defaults to the session tab when no tab is provided", () => {
+		useSessionStore.getState().openConfigModal();
+
+		const state = useSessionStore.getState();
+		expect(state.configModalTab).toBe<ConfigModalTab>("session");
+	});
+
+	it("allows the tab to be updated explicitly", () => {
+		useSessionStore.getState().setConfigModalTab("global");
+
+		const state = useSessionStore.getState();
+		expect(state.configModalTab).toBe<ConfigModalTab>("global");
+	});
+});

--- a/lib/stores/session.ts
+++ b/lib/stores/session.ts
@@ -10,10 +10,15 @@ import type { MessageSender } from "@/lib/types";
 
 export type ChatMode = "voice" | "text";
 
+export type ConfigModalTab = "session" | "global" | "user" | "agent";
+
 interface SessionState {
 	isConfigModalOpen: boolean;
-	openConfigModal: () => void;
+	openConfigModal: (tab?: ConfigModalTab) => void;
 	closeConfigModal: () => void;
+
+	configModalTab: ConfigModalTab;
+	setConfigModalTab: (tab: ConfigModalTab) => void;
 
 	config: StartAvatarRequest | null;
 	setConfig: (config: StartAvatarRequest) => void;
@@ -60,8 +65,15 @@ export const useSessionStore = create<SessionState>()(
 	persist(
 		(set) => ({
 			isConfigModalOpen: true, // Open modal by default
-			openConfigModal: () => set({ isConfigModalOpen: true }),
+			openConfigModal: (tab = "session") =>
+				set({
+					isConfigModalOpen: true,
+					configModalTab: tab,
+				}),
 			closeConfigModal: () => set({ isConfigModalOpen: false }),
+
+			configModalTab: "session",
+			setConfigModalTab: (tab) => set({ configModalTab: tab }),
 
 			config: null,
 			setConfig: (config) => set({ config }),
@@ -144,6 +156,7 @@ export const useSessionStore = create<SessionState>()(
 				globalSettings: state.globalSettings,
 				agentSettings: state.agentSettings,
 				currentSessionId: state.currentSessionId,
+				configModalTab: state.configModalTab,
 			}),
 		},
 	),


### PR DESCRIPTION
## Summary
- add quick links from the sidebar quick settings to open the config modal tabs and drop the API base URL control
- synchronize the session configuration modal with the selected tab in the session store
- cover the new store behavior with a regression test

## Testing
- VITEST_COVERAGE_ENABLED=0 pnpm vitest run lib/stores/_tests/sessionStore.test.ts --environment node

------
https://chatgpt.com/codex/tasks/task_e_68e58a4208508329a74d2a7c5519224a