### PR TITLE
Hook quick start card into session start flow

### DIFF
--- a/components/AvatarSession/AvatarVideoPanel.tsx
+++ b/components/AvatarSession/AvatarVideoPanel.tsx
@@ -1,6 +1,6 @@
 import { Brain, Database, LayoutDashboard } from "lucide-react";
 import type React from "react";
-import { useId, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { StreamingAvatarSessionState } from "../logic/context";
 
@@ -8,33 +8,11 @@ import { AvatarVideo } from "./AvatarVideo";
 import { UserVideo } from "./UserVideo";
 import { AvatarControls } from "./AvatarControls";
 
+import { useAgentStore } from "@/lib/stores/agent";
 import { useSessionStore } from "@/lib/stores/session";
-import { Button } from "@/components/ui/button";
-import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardFooter,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
-import { BorderBeam } from "@/components/magicui/border-beam";
 import { RetroGrid } from "@/components/magicui/retro-grid";
-import { Input } from "@/components/Input";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipProvider,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { useAvatarOptions } from "@/components/AvatarConfig/hooks/useAvatarOptions";
+import { SessionQuickStartCard } from "@/components/AvatarSession/SessionQuickStartCard";
 
 export function AvatarVideoPanel({
 	mediaStream,
@@ -48,35 +26,93 @@ export function AvatarVideoPanel({
 	userVideoStream: MediaStream | null;
 	stopSession: () => void;
 	sessionState: StreamingAvatarSessionState;
-	onStartSession?: (avatarId: string) => void;
+	onStartSession?: (options: {
+		avatarId?: string;
+		knowledgeBaseId?: string;
+	}) => void;
 	onStartWithoutAvatar?: () => void;
 }) {
 	const { viewTab } = useSessionStore();
-	const [selectedAvatar, setSelectedAvatar] = useState<string>("");
-	const [customAvatarId, setCustomAvatarId] = useState<string>("");
-	const { avatarOptions } = useAvatarOptions();
-	const [knowledgeBaseId, setKnowledgeBaseId] = useState<string>("");
+	const { currentAgent, updateAgent } = useAgentStore();
+	const [selectedAvatar, setSelectedAvatar] = useState<string>(
+		currentAgent?.avatarId ?? "",
+	);
+	const [customAvatarId, setCustomAvatarId] = useState<string>(
+		currentAgent?.avatarId ?? "",
+	);
+	const [knowledgeBaseId, setKnowledgeBaseId] = useState<string>(
+		currentAgent?.knowledgeBaseId ?? "",
+	);
+	const selectedAvatarId =
+		selectedAvatar === "CUSTOM" ? customAvatarId.trim() : selectedAvatar;
+	const { avatarOptions, customIdValid } = useAvatarOptions(selectedAvatarId);
 
-	// a11y: generate stable unique IDs for label-control associations
-	const avatarSelectId = useId();
-	const kbInputId = useId();
+	const handleAvatarSelection = (value: string) => {
+		setSelectedAvatar(value);
 
-	const customIdValid = useMemo(() => {
-		if (selectedAvatar !== "CUSTOM") return true;
-		if (!customAvatarId) return false;
+		if (value === "CUSTOM") {
+			const trimmed = customAvatarId.trim();
+			updateAgent({ avatarId: trimmed || undefined });
+			return;
+		}
 
-		return avatarOptions.some((a) => a.avatar_id === customAvatarId);
-	}, [selectedAvatar, customAvatarId, avatarOptions]);
+		updateAgent({ avatarId: value || undefined });
+		setCustomAvatarId("");
+	};
+
+	const handleCustomAvatarChange = (value: string) => {
+		setCustomAvatarId(value);
+		updateAgent({ avatarId: value.trim() || undefined });
+	};
+
+	const handleKnowledgeBaseChange = (value: string) => {
+		setKnowledgeBaseId(value);
+		updateAgent({ knowledgeBaseId: value.trim() || undefined });
+	};
+
+	const forwardStartSession = (payload: {
+		avatarId?: string;
+		knowledgeBaseId?: string;
+	}) => {
+		onStartSession?.(payload);
+	};
+
+	useEffect(() => {
+		if (!currentAgent?.avatarId) {
+			setSelectedAvatar("");
+			setCustomAvatarId("");
+			return;
+		}
+
+		const matches = avatarOptions.some(
+			(option) => option.avatar_id === currentAgent.avatarId,
+		);
+
+		if (matches) {
+			setSelectedAvatar(currentAgent.avatarId);
+			setCustomAvatarId("");
+		} else {
+			setSelectedAvatar("CUSTOM");
+			setCustomAvatarId(currentAgent.avatarId);
+		}
+	}, [avatarOptions, currentAgent?.avatarId]);
+
+	useEffect(() => {
+		setKnowledgeBaseId(currentAgent?.knowledgeBaseId ?? "");
+	}, [currentAgent?.knowledgeBaseId]);
 
 	// Simple client-side check for Knowledge Base ID. If provided, must match a minimal pattern.
 	// Accept UUID-like or alphanumeric with dashes/underscores of length >= 10.
 	const kbIdValid = useMemo(() => {
-		if (!knowledgeBaseId) return true; // optional
+		const value = knowledgeBaseId.trim();
+		if (!value) return true; // optional
 		const uuidLike = /^[0-9a-fA-F-]{10,}$/;
 		const generic = /^[A-Za-z0-9_-]{10,}$/;
 
-		return uuidLike.test(knowledgeBaseId) || generic.test(knowledgeBaseId);
+		return uuidLike.test(value) || generic.test(value);
 	}, [knowledgeBaseId]);
+
+	const isConnecting = sessionState === StreamingAvatarSessionState.CONNECTING;
 
 	return (
 		<div className="group relative w-full h-full bg-background overflow-hidden">
@@ -105,188 +141,20 @@ export function AvatarVideoPanel({
 						<AvatarVideo ref={mediaStream} />
 					) : (
 						<div className="absolute inset-0 flex items-center justify-center">
-							<Card className="relative w-[360px] overflow-hidden border-border bg-card/80 backdrop-blur">
-								<CardHeader>
-									<CardTitle>Select an avatar to start session</CardTitle>
-									<CardDescription>
-										Choose an avatar and click Start Session to begin.
-									</CardDescription>
-								</CardHeader>
-								<CardContent>
-									<div className="grid gap-4">
-										<div className="flex flex-col gap-2">
-											<label
-												className="text-sm text-muted-foreground"
-												htmlFor={avatarSelectId}
-											>
-												Avatar
-											</label>
-											<Select
-												value={selectedAvatar}
-												onValueChange={(v) => setSelectedAvatar(v)}
-											>
-												<SelectTrigger
-													id={avatarSelectId}
-													className="bg-popover/90 border-border text-popover-foreground hover:bg-popover focus:ring-2 focus:ring-ring/50"
-												>
-													<SelectValue placeholder="Select an avatar" />
-												</SelectTrigger>
-												<SelectContent
-													align="start"
-													avoidCollisions={false}
-													className="z-50 bg-popover/95 text-popover-foreground border border-border shadow-xl backdrop-blur"
-													position="popper"
-													side="bottom"
-													sideOffset={4}
-												>
-													{avatarOptions.map((opt) => (
-														<SelectItem
-															key={opt.avatar_id}
-															className="cursor-pointer text-foreground focus:bg-accent data-[highlighted]:bg-accent data-[state=checked]:bg-accent"
-															value={opt.avatar_id}
-														>
-															{opt.name}
-														</SelectItem>
-													))}
-													<SelectItem
-														className="cursor-pointer text-foreground focus:bg-accent data-[highlighted]:bg-accent"
-														value="CUSTOM"
-													>
-														Custom Avatar ID
-													</SelectItem>
-												</SelectContent>
-											</Select>
-											{selectedAvatar === "CUSTOM" && (
-												<div className="mt-2">
-													<Input
-														placeholder="Enter custom agent ID"
-														value={customAvatarId}
-														onChange={setCustomAvatarId}
-													/>
-													{customAvatarId ? (
-														customIdValid ? (
-															<div className="text-primary text-xs mt-1">
-																Agent ID found
-															</div>
-														) : (
-															<div className="text-destructive text-xs mt-1">
-																Agent ID not found in available avatars
-															</div>
-														)
-													) : null}
-												</div>
-											)}
-											{/* Knowledge Base ID (optional) */}
-											<div className="mt-3 flex flex-col gap-2">
-												<label
-													className="text-sm text-muted-foreground"
-													htmlFor={kbInputId}
-												>
-													Knowledge Base ID (optional)
-												</label>
-												<Input
-													id={kbInputId}
-													placeholder="Enter knowledge base ID (if any)"
-													value={knowledgeBaseId}
-													onChange={setKnowledgeBaseId}
-												/>
-												{knowledgeBaseId ? (
-													kbIdValid ? (
-														<div className="text-primary text-xs">
-															Knowledge Base ID format looks good
-														</div>
-													) : (
-														<div className="text-destructive text-xs">
-															Invalid Knowledge Base ID format
-														</div>
-													)
-												) : null}
-											</div>
-										</div>
-									</div>
-								</CardContent>
-								<CardFooter className="flex justify-between gap-2">
-									<Button
-										className="border-border bg-background/70 text-foreground hover:bg-muted"
-										size="sm"
-										variant="outline"
-										onClick={onStartWithoutAvatar}
-									>
-										Start without avatar
-									</Button>
-									<div className="relative inline-flex overflow-hidden rounded-md">
-										{(() => {
-											const isDisabled =
-												!selectedAvatar ||
-												(selectedAvatar === "CUSTOM" &&
-													(!customAvatarId || !customIdValid)) ||
-												(!!knowledgeBaseId && !kbIdValid);
-
-											if (isDisabled) {
-												return (
-													<TooltipProvider>
-														<Tooltip>
-															<TooltipTrigger asChild>
-																<span className="inline-flex">
-																	<Button
-																		disabled
-																		className="bg-secondary text-secondary-foreground"
-																		size="sm"
-																		variant="secondary"
-																		onClick={() =>
-																			onStartSession?.(
-																				selectedAvatar === "CUSTOM"
-																					? customAvatarId
-																					: selectedAvatar,
-																			)
-																		}
-																	>
-																		Start Session
-																	</Button>
-																</span>
-															</TooltipTrigger>
-															<TooltipContent side="top">
-																Set up your agent and settings first
-															</TooltipContent>
-														</Tooltip>
-													</TooltipProvider>
-												);
-											}
-
-											return (
-												<Button
-													className="bg-secondary text-secondary-foreground"
-													size="sm"
-													variant="secondary"
-													onClick={() =>
-														onStartSession?.(
-															selectedAvatar === "CUSTOM"
-																? customAvatarId
-																: selectedAvatar,
-														)
-													}
-												>
-													Start Session
-												</Button>
-											);
-										})()}
-										<BorderBeam borderWidth={2} duration={8} size={80} />
-									</div>
-								</CardFooter>
-								<BorderBeam
-									borderWidth={2}
-									duration={8}
-									initialOffset={10}
-									size={120}
-								/>
-								<BorderBeam
-									reverse
-									borderWidth={2}
-									duration={10}
-									initialOffset={60}
-									size={160}
-								/>
-							</Card>
+							<SessionQuickStartCard
+								avatarOptions={avatarOptions}
+								customAvatarId={customAvatarId}
+								customIdValid={customIdValid}
+								isConnecting={isConnecting}
+								knowledgeBaseId={knowledgeBaseId}
+								kbIdValid={kbIdValid}
+								onCustomAvatarChange={handleCustomAvatarChange}
+								onKnowledgeBaseChange={handleKnowledgeBaseChange}
+								onSelectAvatar={handleAvatarSelection}
+								onStartSession={forwardStartSession}
+								onStartWithoutAvatar={onStartWithoutAvatar}
+								selectedAvatar={selectedAvatar}
+							/>
 						</div>
 					)
 				) : (

--- a/components/AvatarSession/SessionQuickStartCard.tsx
+++ b/components/AvatarSession/SessionQuickStartCard.tsx
@@ -1,0 +1,239 @@
+import type { AvatarOption } from "@/components/AvatarConfig/hooks/useAvatarOptions";
+import { Input } from "@/components/Input";
+import { BorderBeam } from "@/components/magicui/border-beam";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardFooter,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useId } from "react";
+
+interface SessionQuickStartCardProps {
+	avatarOptions: AvatarOption[];
+	selectedAvatar: string;
+	customAvatarId: string;
+	knowledgeBaseId: string;
+	kbIdValid: boolean;
+	customIdValid: boolean;
+	isConnecting: boolean;
+	onSelectAvatar: (value: string) => void;
+	onCustomAvatarChange: (value: string) => void;
+	onKnowledgeBaseChange: (value: string) => void;
+	onStartSession: (options: {
+		avatarId?: string;
+		knowledgeBaseId?: string;
+	}) => void;
+	onStartWithoutAvatar?: () => void;
+}
+
+/**
+ * Presents the pre-session configuration card within the video panel so that users can
+ * quickly pick an avatar, supply optional knowledge base details, and kick off a session
+ * without opening the full configuration modal.
+ */
+export function SessionQuickStartCard({
+	avatarOptions,
+	selectedAvatar,
+	customAvatarId,
+	knowledgeBaseId,
+	kbIdValid,
+	customIdValid,
+	isConnecting,
+	onSelectAvatar,
+	onCustomAvatarChange,
+	onKnowledgeBaseChange,
+	onStartSession,
+	onStartWithoutAvatar,
+}: SessionQuickStartCardProps) {
+	const avatarSelectId = useId();
+	const kbInputId = useId();
+
+	const finalAvatarId =
+		selectedAvatar === "CUSTOM" ? customAvatarId.trim() : selectedAvatar;
+	const finalKnowledgeId = knowledgeBaseId.trim() || undefined;
+	const isStartDisabled =
+		isConnecting ||
+		!finalAvatarId ||
+		(selectedAvatar === "CUSTOM" &&
+			(!customAvatarId.trim() || !customIdValid)) ||
+		(finalKnowledgeId && !kbIdValid);
+
+	const triggerStart = () => {
+		onStartSession({
+			avatarId: finalAvatarId,
+			knowledgeBaseId: finalKnowledgeId,
+		});
+	};
+
+	return (
+		<Card className="relative w-[360px] overflow-hidden border-border bg-card/80 backdrop-blur">
+			<CardHeader>
+				<CardTitle>Select an avatar to start session</CardTitle>
+				<CardDescription>
+					Choose an avatar and click Start Session to begin.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<div className="grid gap-4">
+					<div className="flex flex-col gap-2">
+						<label
+							className="text-sm text-muted-foreground"
+							htmlFor={avatarSelectId}
+						>
+							Avatar
+						</label>
+						<Select value={selectedAvatar} onValueChange={onSelectAvatar}>
+							<SelectTrigger
+								id={avatarSelectId}
+								className="bg-popover/90 border-border text-popover-foreground hover:bg-popover focus:ring-2 focus:ring-ring/50"
+							>
+								<SelectValue placeholder="Select an avatar" />
+							</SelectTrigger>
+							<SelectContent
+								align="start"
+								avoidCollisions={false}
+								className="z-50 bg-popover/95 text-popover-foreground border border-border shadow-xl backdrop-blur"
+								position="popper"
+								side="bottom"
+								sideOffset={4}
+							>
+								{avatarOptions.map((opt) => (
+									<SelectItem
+										key={opt.avatar_id}
+										className="cursor-pointer text-foreground focus:bg-accent data-[highlighted]:bg-accent data-[state=checked]:bg-accent"
+										value={opt.avatar_id}
+									>
+										{opt.name}
+									</SelectItem>
+								))}
+								<SelectItem
+									className="cursor-pointer text-foreground focus:bg-accent data-[highlighted]:bg-accent"
+									value="CUSTOM"
+								>
+									Custom Avatar ID
+								</SelectItem>
+							</SelectContent>
+						</Select>
+						{selectedAvatar === "CUSTOM" && (
+							<div className="mt-2">
+								<Input
+									placeholder="Enter custom agent ID"
+									value={customAvatarId}
+									onChange={onCustomAvatarChange}
+								/>
+								{customAvatarId ? (
+									customIdValid ? (
+										<div className="text-primary text-xs mt-1">
+											Agent ID found
+										</div>
+									) : (
+										<div className="text-destructive text-xs mt-1">
+											Agent ID not found in available avatars
+										</div>
+									)
+								) : null}
+							</div>
+						)}
+						<div className="mt-3 flex flex-col gap-2">
+							<label
+								className="text-sm text-muted-foreground"
+								htmlFor={kbInputId}
+							>
+								Knowledge Base ID (optional)
+							</label>
+							<Input
+								id={kbInputId}
+								placeholder="Enter knowledge base ID (if any)"
+								value={knowledgeBaseId}
+								onChange={onKnowledgeBaseChange}
+							/>
+							{knowledgeBaseId ? (
+								kbIdValid ? (
+									<div className="text-primary text-xs">
+										Knowledge Base ID format looks good
+									</div>
+								) : (
+									<div className="text-destructive text-xs">
+										Invalid Knowledge Base ID format
+									</div>
+								)
+							) : null}
+						</div>
+					</div>
+				</div>
+			</CardContent>
+			<CardFooter className="flex justify-between gap-2">
+				<Button
+					className="border-border bg-background/70 text-foreground hover:bg-muted"
+					size="sm"
+					variant="outline"
+					onClick={onStartWithoutAvatar}
+				>
+					Start without avatar
+				</Button>
+				<div className="relative inline-flex overflow-hidden rounded-md">
+					{isStartDisabled ? (
+						<TooltipProvider>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<span className="inline-flex">
+										<Button
+											disabled
+											className="bg-secondary text-secondary-foreground"
+											size="sm"
+											variant="secondary"
+											onClick={triggerStart}
+										>
+											{isConnecting ? "Connecting..." : "Start Session"}
+										</Button>
+									</span>
+								</TooltipTrigger>
+								<TooltipContent side="top">
+									{isConnecting
+										? "Connecting to avatar..."
+										: "Set up your agent and settings first"}
+								</TooltipContent>
+							</Tooltip>
+						</TooltipProvider>
+					) : (
+						<Button
+							className="bg-secondary text-secondary-foreground"
+							disabled={isConnecting}
+							size="sm"
+							variant="secondary"
+							onClick={triggerStart}
+						>
+							{isConnecting ? "Connecting..." : "Start Session"}
+						</Button>
+					)}
+					<BorderBeam borderWidth={2} duration={8} size={80} />
+				</div>
+			</CardFooter>
+			<BorderBeam borderWidth={2} duration={8} initialOffset={10} size={120} />
+			<BorderBeam
+				reverse
+				borderWidth={2}
+				duration={10}
+				initialOffset={60}
+				size={160}
+			/>
+		</Card>
+	);
+}

--- a/components/InteractiveAvatar.tsx
+++ b/components/InteractiveAvatar.tsx
@@ -168,8 +168,10 @@ function InteractiveAvatarCore() {
 			</div>
 			<div className="w-full h-full">
 				<AvatarSession
+					initialConfig={DEFAULT_CONFIG}
 					mediaStream={mediaStreamRef}
 					sessionState={sessionState}
+					startSession={startSessionV2}
 					stopSession={stopSessionV2}
 				/>
 			</div>

--- a/components/modals/session/__tests__/utils.test.ts
+++ b/components/modals/session/__tests__/utils.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSessionConfig } from "../utils";
+
+describe("buildSessionConfig", () => {
+	const baseConfig = {
+		quality: "Low",
+		avatarName: "base-avatar",
+		knowledgeId: "base-kb",
+		language: "en",
+		voiceChatTransport: "WEBSOCKET",
+		sttSettings: { provider: "deepgram" },
+		voice: {
+			voiceId: "base-voice",
+			rate: 1,
+			emotion: "CALM",
+			model: "base-model",
+		},
+	} as any;
+
+	it("merges agent and user settings into the start config", () => {
+		const agentConfig = {
+			avatarId: "agent-avatar",
+			knowledgeBaseId: "agent-kb",
+			language: "de",
+			voiceId: "agent-voice",
+			voice: {
+				rate: 1.25,
+				emotion: "HAPPY",
+				elevenlabs_settings: { model_id: "agent-model" },
+			},
+			voiceChatTransport: "SFU",
+			stt: { provider: "azure" },
+		} as any;
+
+		const userSettings = {
+			language: "fr",
+			quality: "medium",
+		} as any;
+
+		const result = buildSessionConfig({
+			baseConfig,
+			agentConfig,
+			userSettings,
+		});
+
+		expect(result.avatarName).toBe("agent-avatar");
+		expect(result.knowledgeId).toBe("agent-kb");
+		expect(result.language).toBe("fr");
+		expect(result.quality).toBe("Medium");
+		expect(result.voice?.voiceId).toBe("agent-voice");
+		expect(result.voice?.rate).toBe(1.25);
+		expect(result.voice?.emotion).toBe("HAPPY");
+		expect(result.voice?.model).toBe("agent-model");
+		expect(result.voiceChatTransport).toBe("SFU");
+		expect(result.sttSettings?.provider).toBe("azure");
+	});
+
+	it("applies inline overrides on top of agent and user settings", () => {
+		const agentConfig = {
+			avatarId: "agent-avatar",
+			knowledgeBaseId: "agent-kb",
+			language: "de",
+		} as any;
+
+		const overrides = {
+			avatarId: "override-avatar",
+			knowledgeBaseId: "override-kb",
+			language: "it",
+		};
+
+		const result = buildSessionConfig({
+			baseConfig,
+			agentConfig,
+			overrides,
+		});
+
+		expect(result.avatarName).toBe("override-avatar");
+		expect(result.knowledgeId).toBe("override-kb");
+		expect(result.language).toBe("it");
+	});
+});

--- a/components/ui/SessionConfigModal.tsx
+++ b/components/ui/SessionConfigModal.tsx
@@ -14,8 +14,8 @@ import { useDynamicOptions } from "../modals/session/hooks";
 import { PublishAgentModal } from "../modals/session/PublishAgentModal";
 import {
 	applyUserSettingsToConfig,
+	buildSessionConfig,
 	initFormsFromStorage,
-	mapAgentAndSettingsToConfig,
 } from "../modals/session/utils";
 import { SessionConfigHeader } from "../modals/session/Header";
 
@@ -94,11 +94,11 @@ export function SessionConfigModal({
 
 			setLastStarted(latestAgent as any);
 			markClean();
-			finalConfig = mapAgentAndSettingsToConfig(
-				config,
-				latestAgent,
+			finalConfig = buildSessionConfig({
+				baseConfig: config,
+				agentConfig: latestAgent,
 				userSettings,
-			);
+			});
 		} catch {
 			// fallback to current config
 		}


### PR DESCRIPTION
## Summary
- build a shared `buildSessionConfig` helper so session starts reuse agent and user settings
- wire the quick-start card in the video panel to launch sessions and extract it into `SessionQuickStartCard`
- add targeted tests covering the new configuration builder logic

## Testing
- pnpm vitest run components/modals/session/__tests__/utils.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e59cf2c39483299879ffda9ab064c7