### PR TITLE
feat: add Gemini Vertex API route handlers

### DIFF
--- a/app/api/gemini-vertix/_tests/client.test.ts
+++ b/app/api/gemini-vertix/_tests/client.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createGeminiVertexClient, GeminiVertexAPIError } from "../sdk";
+import type { GenerateContentRequest } from "../sdk";
+
+const baseConfig = {
+	project: "demo-project",
+	location: "us-central1",
+	model: "gemini-1.5-pro",
+	accessToken: "ya29.mock-token",
+};
+
+describe("createGeminiVertexClient", () => {
+	const body: GenerateContentRequest = {
+		contents: [{ parts: [{ text: "Hello" }] }],
+	};
+
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("sends generateContent requests to the Vertex endpoint", async () => {
+		fetchMock.mockResolvedValue(
+			new Response(JSON.stringify({ candidates: [] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+
+		const client = createGeminiVertexClient({
+			...baseConfig,
+			fetch: fetchMock as unknown as typeof fetch,
+		});
+
+		await client.generateContent(body, {
+			headers: { "X-Custom": "demo" },
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe(
+			"https://us-central1-aiplatform.googleapis.com/v1/projects/demo-project/locations/us-central1/publishers/google/models/gemini-1.5-pro:generateContent",
+		);
+
+		expect(init.method).toBe("POST");
+		expect(init.body).toBe(JSON.stringify(body));
+		const headers = new Headers(init.headers);
+		expect(headers.get("Authorization")).toBe("Bearer ya29.mock-token");
+		expect(headers.get("Content-Type")).toBe("application/json");
+		expect(headers.get("Accept")).toBe("application/json");
+		expect(headers.get("X-Custom")).toBe("demo");
+	});
+
+	it("allows per-request overrides for model routing and authorization", async () => {
+		fetchMock.mockResolvedValue(
+			new Response(JSON.stringify({ candidates: [] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+
+		const client = createGeminiVertexClient({
+			...baseConfig,
+			fetch: fetchMock as unknown as typeof fetch,
+		});
+
+		await client.generateContent(body, {
+			project: "override-project",
+			location: "europe-west1",
+			model: "gemini-1.5-flash",
+			accessToken: "ya29.override",
+		});
+
+		const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe(
+			"https://europe-west1-aiplatform.googleapis.com/v1/projects/override-project/locations/europe-west1/publishers/google/models/gemini-1.5-flash:generateContent",
+		);
+		const headers = new Headers(init.headers);
+		expect(headers.get("Authorization")).toBe("Bearer ya29.override");
+	});
+
+	it("streams newline delimited JSON chunks", async () => {
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(
+					encoder.encode(
+						`${JSON.stringify({
+							candidates: [
+								{
+									content: { parts: [{ text: "Hi" }] },
+								},
+							],
+						})}\n`,
+					),
+				);
+				controller.enqueue(
+					encoder.encode(
+						`${JSON.stringify({ usageMetadata: { totalTokens: 4 } })}\n`,
+					),
+				);
+				controller.close();
+			},
+		});
+
+		fetchMock.mockResolvedValue(
+			new Response(stream, {
+				status: 200,
+				headers: { "Content-Type": "application/x-ndjson" },
+			}),
+		);
+
+		const client = createGeminiVertexClient({
+			...baseConfig,
+			fetch: fetchMock as unknown as typeof fetch,
+		});
+
+		const chunks: unknown[] = [];
+		for await (const chunk of client.streamGenerateContent(body)) {
+			chunks.push(chunk);
+		}
+
+		expect(chunks).toHaveLength(2);
+		expect(chunks[0]).toMatchObject({
+			candidates: [{ content: { parts: [{ text: "Hi" }] } }],
+		});
+		expect(chunks[1]).toMatchObject({ usageMetadata: { totalTokens: 4 } });
+	});
+
+	it("parses streaming chunks prefixed with data markers and ignores keepalive signals", async () => {
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(
+					encoder.encode('data: {"candidates":[{"index":0}]}\n'),
+				);
+				controller.enqueue(encoder.encode("\n"));
+				controller.enqueue(encoder.encode("event: ping\n"));
+				controller.enqueue(encoder.encode("data: [DONE]\n"));
+				controller.close();
+			},
+		});
+
+		fetchMock.mockResolvedValue(
+			new Response(stream, {
+				status: 200,
+				headers: { "Content-Type": "application/x-ndjson" },
+			}),
+		);
+
+		const client = createGeminiVertexClient({
+			...baseConfig,
+			fetch: fetchMock as unknown as typeof fetch,
+		});
+
+		const chunks: unknown[] = [];
+		for await (const chunk of client.streamGenerateContent(body)) {
+			chunks.push(chunk);
+		}
+
+		expect(chunks).toHaveLength(1);
+		expect(chunks[0]).toMatchObject({ candidates: [{ index: 0 }] });
+	});
+
+	it("throws a GeminiVertexAPIError on error responses", async () => {
+		fetchMock.mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					error: {
+						code: 400,
+						message: "Invalid model",
+						status: "INVALID_ARGUMENT",
+					},
+				}),
+				{
+					status: 400,
+					headers: { "Content-Type": "application/json" },
+				},
+			),
+		);
+
+		const client = createGeminiVertexClient({
+			...baseConfig,
+			fetch: fetchMock as unknown as typeof fetch,
+		});
+
+		const error = await client
+			.countTokens(body)
+			.catch((err) => err as GeminiVertexAPIError);
+		expect(error).toBeInstanceOf(GeminiVertexAPIError);
+		expect(error.status).toBe(400);
+		expect(error.message).toBe("Invalid model");
+	});
+});

--- a/app/api/gemini-vertix/_tests/modules.test.ts
+++ b/app/api/gemini-vertix/_tests/modules.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+	CountTokensRequest,
+	GenerateContentRequest,
+	StreamingResponseChunk,
+} from "../sdk";
+import { countTokens } from "../modules/count-tokens";
+import { generateContent } from "../modules/generate-content";
+import { streamGenerateContent } from "../modules/stream-generate-content";
+
+const baseRequest: GenerateContentRequest = {
+	contents: [
+		{
+			parts: [{ text: "Hello" }],
+		},
+	],
+};
+
+const baseCountRequest: CountTokensRequest = {
+	contents: baseRequest.contents,
+};
+
+const envKeys = [
+	"GEMINI_VERTEX_PROJECT",
+	"GEMINI_VERTEX_LOCATION",
+	"GEMINI_VERTEX_MODEL",
+];
+
+describe("Gemini Vertex modules", () => {
+	const originalEnv: Record<string, string | undefined> = {};
+
+	beforeEach(() => {
+		envKeys.forEach((key) => {
+			originalEnv[key] = process.env[key];
+		});
+		process.env.GEMINI_VERTEX_PROJECT = "demo-project";
+		process.env.GEMINI_VERTEX_LOCATION = "us-central1";
+		process.env.GEMINI_VERTEX_MODEL = "gemini-1.5-pro";
+	});
+
+	afterEach(() => {
+		envKeys.forEach((key) => {
+			if (originalEnv[key] === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = originalEnv[key];
+			}
+		});
+		vi.restoreAllMocks();
+	});
+
+	it("delegates generateContent to the SDK and returns the response payload", async () => {
+		const responsePayload = { candidates: [{ index: 0 }] };
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify(responsePayload), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+
+		const result = await generateContent(baseRequest, {
+			clientConfig: {
+				accessToken: "ya29.test",
+				fetch: fetchMock as unknown as typeof fetch,
+			},
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.status).toBe(200);
+			expect(result.data).toEqual(responsePayload);
+		}
+	});
+
+	it("delegates countTokens to the SDK", async () => {
+		const responsePayload = { totalTokens: 42 };
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify(responsePayload), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+
+		const result = await countTokens(baseCountRequest, {
+			clientConfig: {
+				accessToken: "ya29.test",
+				fetch: fetchMock as unknown as typeof fetch,
+			},
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toEqual(responsePayload);
+		}
+	});
+
+	it("returns a stream iterator for streamGenerateContent", async () => {
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(
+					encoder.encode(`${JSON.stringify({ candidates: [{ index: 0 }] })}\n`),
+				);
+				controller.close();
+			},
+		});
+
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(stream, {
+				status: 200,
+				headers: { "Content-Type": "application/x-ndjson" },
+			}),
+		);
+
+		const result = await streamGenerateContent(baseRequest, {
+			clientConfig: {
+				accessToken: "ya29.test",
+				fetch: fetchMock as unknown as typeof fetch,
+			},
+		});
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			const chunks: StreamingResponseChunk[] = [];
+			for await (const chunk of result.stream) {
+				chunks.push(chunk);
+			}
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			expect(chunks).toHaveLength(1);
+			expect(chunks[0]).toMatchObject({ candidates: [{ index: 0 }] });
+		}
+	});
+
+	it("normalises GeminiVertexAPIError instances into error payloads", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					error: {
+						code: 400,
+						message: "Invalid request",
+						status: "INVALID_ARGUMENT",
+					},
+				}),
+				{
+					status: 400,
+					headers: { "Content-Type": "application/json" },
+				},
+			),
+		);
+
+		const result = await generateContent(baseRequest, {
+			clientConfig: {
+				accessToken: "ya29.test",
+				fetch: fetchMock as unknown as typeof fetch,
+			},
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.status).toBe(400);
+			expect(result.error).toMatchObject({
+				code: 400,
+				message: "Invalid request",
+				status: "INVALID_ARGUMENT",
+			});
+		}
+	});
+
+	it("returns a 400 error payload when validation fails", async () => {
+		const invalidPayload = { contents: null } as unknown;
+
+		const result = await generateContent(invalidPayload, {
+			clientConfig: {
+				accessToken: "ya29.test",
+				fetch: vi.fn(),
+			},
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.status).toBe(400);
+			expect(result.error.message).toContain("contents");
+		}
+	});
+});

--- a/app/api/gemini-vertix/_tests/routes.test.ts
+++ b/app/api/gemini-vertix/_tests/routes.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const jsonHeaders = { "Content-Type": "application/json" };
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("Gemini Vertex API routes", () => {
+	it("returns JSON for generateContent successes", async () => {
+		const module = await import("../modules/generate-content");
+		vi.spyOn(module, "generateContent").mockResolvedValue({
+			ok: true,
+			status: 201,
+			data: { candidates: [{ index: 0 }] },
+		});
+		const { POST } = await import("../generate-content/route");
+
+		const request = new Request("http://localhost", {
+			method: "POST",
+			headers: jsonHeaders,
+			body: JSON.stringify({ contents: [] }),
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(201);
+		expect(response.headers.get("content-type")).toContain("application/json");
+		expect(await response.json()).toEqual({ candidates: [{ index: 0 }] });
+	});
+
+	it("surfaces module errors from generateContent", async () => {
+		const module = await import("../modules/generate-content");
+		vi.spyOn(module, "generateContent").mockResolvedValue({
+			ok: false,
+			status: 422,
+			error: { code: 422, message: "Invalid" },
+		});
+		const { POST } = await import("../generate-content/route");
+
+		const request = new Request("http://localhost", {
+			method: "POST",
+			headers: jsonHeaders,
+			body: JSON.stringify({ contents: [] }),
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(422);
+		expect(await response.json()).toEqual({ code: 422, message: "Invalid" });
+	});
+
+	it("returns 400 when generateContent receives invalid JSON", async () => {
+		const module = await import("../modules/generate-content");
+		vi.spyOn(module, "generateContent").mockResolvedValue({
+			ok: true,
+			status: 200,
+			data: {},
+		});
+		const { POST } = await import("../generate-content/route");
+
+		const request = new Request("http://localhost", {
+			method: "POST",
+			headers: jsonHeaders,
+			body: "invalid",
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({
+			code: 400,
+			message: "Invalid JSON body",
+		});
+	});
+
+	it("returns JSON for countTokens successes", async () => {
+		const module = await import("../modules/count-tokens");
+		vi.spyOn(module, "countTokens").mockResolvedValue({
+			ok: true,
+			status: 200,
+			data: { totalTokens: 99 },
+		});
+		const { POST } = await import("../count-tokens/route");
+
+		const request = new Request("http://localhost", {
+			method: "POST",
+			headers: jsonHeaders,
+			body: JSON.stringify({ contents: [] }),
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ totalTokens: 99 });
+	});
+
+	it("streams NDJSON for streamGenerateContent successes", async () => {
+		const module = await import("../modules/stream-generate-content");
+		async function* chunks() {
+			yield { candidates: [{ index: 0 }] };
+			yield { candidates: [{ index: 1 }] };
+		}
+		vi.spyOn(module, "streamGenerateContent").mockResolvedValue({
+			ok: true,
+			status: 200,
+			stream: chunks(),
+		});
+		const { POST } = await import("../stream-generate-content/route");
+
+		const request = new Request("http://localhost", {
+			method: "POST",
+			headers: jsonHeaders,
+			body: JSON.stringify({ contents: [] }),
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toContain(
+			"application/x-ndjson",
+		);
+		const text = await response.text();
+		expect(text).toBe(
+			'{"candidates":[{"index":0}]}\n{"candidates":[{"index":1}]}\n',
+		);
+	});
+
+	it("returns JSON errors for streamGenerateContent failures", async () => {
+		const module = await import("../modules/stream-generate-content");
+		vi.spyOn(module, "streamGenerateContent").mockResolvedValue({
+			ok: false,
+			status: 401,
+			error: { code: 401, message: "Unauthorised" },
+		});
+		const { POST } = await import("../stream-generate-content/route");
+
+		const request = new Request("http://localhost", {
+			method: "POST",
+			headers: jsonHeaders,
+			body: JSON.stringify({ contents: [] }),
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(401);
+		expect(await response.json()).toEqual({
+			code: 401,
+			message: "Unauthorised",
+		});
+	});
+});

--- a/app/api/gemini-vertix/count-tokens/route.ts
+++ b/app/api/gemini-vertix/count-tokens/route.ts
@@ -1,0 +1,35 @@
+import { countTokens } from "../modules/count-tokens";
+
+function invalidJsonResponse(): Response {
+	return new Response(
+		JSON.stringify({ code: 400, message: "Invalid JSON body" }),
+		{
+			status: 400,
+			headers: { "Content-Type": "application/json" },
+		},
+	);
+}
+
+export async function POST(request: Request): Promise<Response> {
+	let payload: unknown;
+	try {
+		payload = await request.json();
+	} catch (error) {
+		console.error("Failed to parse countTokens request", error);
+		return invalidJsonResponse();
+	}
+
+	const result = await countTokens(payload);
+
+	if (result.ok) {
+		return new Response(JSON.stringify(result.data), {
+			status: result.status,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+
+	return new Response(JSON.stringify(result.error), {
+		status: result.status,
+		headers: { "Content-Type": "application/json" },
+	});
+}

--- a/app/api/gemini-vertix/generate-content/route.ts
+++ b/app/api/gemini-vertix/generate-content/route.ts
@@ -1,0 +1,35 @@
+import { generateContent } from "../modules/generate-content";
+
+function invalidJsonResponse(): Response {
+	return new Response(
+		JSON.stringify({ code: 400, message: "Invalid JSON body" }),
+		{
+			status: 400,
+			headers: { "Content-Type": "application/json" },
+		},
+	);
+}
+
+export async function POST(request: Request): Promise<Response> {
+	let payload: unknown;
+	try {
+		payload = await request.json();
+	} catch (error) {
+		console.error("Failed to parse generateContent request", error);
+		return invalidJsonResponse();
+	}
+
+	const result = await generateContent(payload);
+
+	if (result.ok) {
+		return new Response(JSON.stringify(result.data), {
+			status: result.status,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+
+	return new Response(JSON.stringify(result.error), {
+		status: result.status,
+		headers: { "Content-Type": "application/json" },
+	});
+}

--- a/app/api/gemini-vertix/modules/count-tokens.ts
+++ b/app/api/gemini-vertix/modules/count-tokens.ts
@@ -1,0 +1,27 @@
+import type { CountTokensResponse } from "../sdk";
+import {
+	ModuleError,
+	ModuleOptions,
+	ModuleSuccess,
+	normaliseError,
+	splitModuleOptions,
+	validateCountTokensRequest,
+} from "./shared";
+
+export type CountTokensResult =
+	| ModuleSuccess<CountTokensResponse>
+	| ModuleError;
+
+export async function countTokens(
+	payload: unknown,
+	options?: ModuleOptions,
+): Promise<CountTokensResult> {
+	try {
+		const body = validateCountTokensRequest(payload);
+		const { client, requestOptions } = splitModuleOptions(options);
+		const data = await client.countTokens(body, requestOptions);
+		return { ok: true, status: 200, data };
+	} catch (error) {
+		return normaliseError(error);
+	}
+}

--- a/app/api/gemini-vertix/modules/generate-content.ts
+++ b/app/api/gemini-vertix/modules/generate-content.ts
@@ -1,0 +1,27 @@
+import type { GenerateContentResponse } from "../sdk";
+import {
+	ModuleError,
+	ModuleOptions,
+	ModuleSuccess,
+	normaliseError,
+	splitModuleOptions,
+	validateGenerateContentRequest,
+} from "./shared";
+
+export type GenerateContentResult =
+	| ModuleSuccess<GenerateContentResponse>
+	| ModuleError;
+
+export async function generateContent(
+	payload: unknown,
+	options?: ModuleOptions,
+): Promise<GenerateContentResult> {
+	try {
+		const body = validateGenerateContentRequest(payload);
+		const { client, requestOptions } = splitModuleOptions(options);
+		const data = await client.generateContent(body, requestOptions);
+		return { ok: true, status: 200, data };
+	} catch (error) {
+		return normaliseError(error);
+	}
+}

--- a/app/api/gemini-vertix/modules/shared.ts
+++ b/app/api/gemini-vertix/modules/shared.ts
@@ -1,0 +1,239 @@
+import { createGeminiVertexClient, GeminiVertexAPIError } from "../sdk";
+import type {
+	Content,
+	CountTokensRequest,
+	GeminiVertexClient,
+	GeminiVertexClientConfig,
+	GenerateContentRequest,
+	RequestOptions,
+	StreamingResponseChunk,
+	VertexErrorPayload,
+} from "../sdk";
+
+const ENV_KEYS = {
+	project: [
+		"GEMINI_VERTEX_PROJECT",
+		"VERTEX_GEMINI_PROJECT",
+		"GOOGLE_VERTEX_PROJECT",
+	],
+	location: [
+		"GEMINI_VERTEX_LOCATION",
+		"VERTEX_GEMINI_LOCATION",
+		"GOOGLE_VERTEX_LOCATION",
+	],
+	model: ["GEMINI_VERTEX_MODEL", "VERTEX_GEMINI_MODEL", "GOOGLE_VERTEX_MODEL"],
+	baseUrl: [
+		"GEMINI_VERTEX_BASE_URL",
+		"VERTEX_GEMINI_BASE_URL",
+		"GOOGLE_VERTEX_BASE_URL",
+	],
+	accessToken: [
+		"GEMINI_VERTEX_ACCESS_TOKEN",
+		"VERTEX_GEMINI_ACCESS_TOKEN",
+		"GOOGLE_VERTEX_ACCESS_TOKEN",
+	],
+} as const;
+
+export interface ModuleOptions extends RequestOptions {
+	clientConfig?: Partial<GeminiVertexClientConfig>;
+}
+
+export interface ModuleSuccess<T> {
+	ok: true;
+	status: number;
+	data: T;
+}
+
+export interface ModuleStreamSuccess {
+	ok: true;
+	status: number;
+	stream: AsyncIterable<StreamingResponseChunk>;
+}
+
+export interface ModuleError {
+	ok: false;
+	status: number;
+	error: VertexErrorPayload;
+}
+
+class ValidationError extends Error {
+	readonly status: number;
+
+	constructor(message: string, status = 400) {
+		super(message);
+		this.name = "ValidationError";
+		this.status = status;
+	}
+}
+
+function readEnv(keys: readonly string[]): string | undefined {
+	for (const key of keys) {
+		const value = process.env[key];
+		if (value) return value;
+	}
+	return undefined;
+}
+
+function ensureValue(value: string | undefined, label: string): string {
+	if (!value) {
+		throw new ValidationError(
+			`Missing Gemini Vertex configuration: ${label}`,
+			500,
+		);
+	}
+	return value;
+}
+
+function mergeClientConfig(
+	overrides?: Partial<GeminiVertexClientConfig>,
+): GeminiVertexClientConfig {
+	const project = overrides?.project ?? readEnv(ENV_KEYS.project);
+	const location = overrides?.location ?? readEnv(ENV_KEYS.location);
+	const model = overrides?.model ?? readEnv(ENV_KEYS.model);
+
+	const config: GeminiVertexClientConfig = {
+		project: ensureValue(project, "project"),
+		location: ensureValue(location, "location"),
+		model: ensureValue(model, "model"),
+	};
+
+	const accessToken = overrides?.accessToken ?? readEnv(ENV_KEYS.accessToken);
+	if (accessToken) {
+		config.accessToken = accessToken;
+	}
+
+	const baseUrl = overrides?.baseUrl ?? readEnv(ENV_KEYS.baseUrl);
+	if (baseUrl) {
+		config.baseUrl = baseUrl;
+	}
+
+	if (overrides?.fetch) {
+		config.fetch = overrides.fetch;
+	}
+
+	return config;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function validateContent(
+	content: unknown,
+	index: number,
+): asserts content is Content {
+	if (!isRecord(content)) {
+		throw new ValidationError(
+			`contents[${index}] must be an object with a parts array`,
+		);
+	}
+	if (!Array.isArray((content as Content).parts)) {
+		throw new ValidationError(`contents[${index}].parts must be an array`);
+	}
+}
+
+export function validateGenerateContentRequest(
+	payload: unknown,
+): GenerateContentRequest {
+	if (!isRecord(payload)) {
+		throw new ValidationError(
+			"Request body must be an object with a contents array",
+		);
+	}
+	if (!Array.isArray(payload.contents)) {
+		throw new ValidationError("Request body must include a contents array");
+	}
+	payload.contents.forEach((content, index) => {
+		validateContent(content, index);
+	});
+	return payload as GenerateContentRequest;
+}
+
+export function validateCountTokensRequest(
+	payload: unknown,
+): CountTokensRequest {
+	if (!isRecord(payload)) {
+		throw new ValidationError(
+			"Request body must be an object with a contents array",
+		);
+	}
+	if (!Array.isArray(payload.contents)) {
+		throw new ValidationError("Request body must include a contents array");
+	}
+	payload.contents.forEach((content, index) => {
+		validateContent(content, index);
+	});
+	return payload as CountTokensRequest;
+}
+
+function extractVertexError(
+	details: unknown,
+	fallback: number,
+	message: string,
+): VertexErrorPayload {
+	if (isRecord(details) && isRecord(details.error)) {
+		const error = details.error as VertexErrorPayload;
+		return {
+			code: error.code ?? fallback,
+			message: error.message ?? message,
+			status: error.status,
+			details: error.details,
+		};
+	}
+	if (Array.isArray(details)) {
+		return {
+			code: fallback,
+			message,
+			details: details as Record<string, unknown>[],
+		};
+	}
+	if (isRecord(details)) {
+		return {
+			code: fallback,
+			message,
+			details: [details as Record<string, unknown>],
+		};
+	}
+	return { code: fallback, message };
+}
+
+export function normaliseError(error: unknown): ModuleError {
+	if (error instanceof ValidationError) {
+		return {
+			ok: false,
+			status: error.status,
+			error: {
+				code: error.status,
+				message: error.message,
+			},
+		};
+	}
+	if (error instanceof GeminiVertexAPIError) {
+		return {
+			ok: false,
+			status: error.status,
+			error: extractVertexError(error.details, error.status, error.message),
+		};
+	}
+	throw error;
+}
+
+export function createClient(
+	options?: Partial<GeminiVertexClientConfig>,
+): GeminiVertexClient {
+	const config = mergeClientConfig(options);
+	return createGeminiVertexClient(config);
+}
+
+export function splitModuleOptions(options?: ModuleOptions): {
+	client: GeminiVertexClient;
+	requestOptions: RequestOptions | undefined;
+} {
+	const clientOverrides = options?.clientConfig;
+	const client = createClient(clientOverrides);
+	const { clientConfig, ...requestOptions } = options ?? {};
+	const request: RequestOptions | undefined = Object.keys(requestOptions).length
+		? (requestOptions as RequestOptions)
+		: undefined;
+	return { client, requestOptions: request };
+}

--- a/app/api/gemini-vertix/modules/stream-generate-content.ts
+++ b/app/api/gemini-vertix/modules/stream-generate-content.ts
@@ -1,0 +1,24 @@
+import {
+	ModuleError,
+	ModuleOptions,
+	ModuleStreamSuccess,
+	normaliseError,
+	splitModuleOptions,
+	validateGenerateContentRequest,
+} from "./shared";
+
+export type StreamGenerateContentResult = ModuleStreamSuccess | ModuleError;
+
+export async function streamGenerateContent(
+	payload: unknown,
+	options?: ModuleOptions,
+): Promise<StreamGenerateContentResult> {
+	try {
+		const body = validateGenerateContentRequest(payload);
+		const { client, requestOptions } = splitModuleOptions(options);
+		const stream = client.streamGenerateContent(body, requestOptions);
+		return { ok: true, status: 200, stream };
+	} catch (error) {
+		return normaliseError(error);
+	}
+}

--- a/app/api/gemini-vertix/sdk/client.ts
+++ b/app/api/gemini-vertix/sdk/client.ts
@@ -1,0 +1,292 @@
+import type {
+	CountTokensRequest,
+	CountTokensResponse,
+	GenerateContentRequest,
+	GenerateContentResponse,
+	StreamingResponseChunk,
+} from "./types";
+
+export interface GeminiVertexClientConfig {
+	project: string;
+	location: string;
+	model: string;
+	accessToken?: string;
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+
+export interface RequestOptions {
+	project?: string;
+	location?: string;
+	model?: string;
+	accessToken?: string;
+	signal?: AbortSignal;
+	headers?: Record<string, string>;
+}
+
+export class GeminiVertexAPIError extends Error {
+	readonly status: number;
+	readonly details?: unknown;
+
+	constructor(message: string, status: number, details?: unknown) {
+		super(message);
+		this.name = "GeminiVertexAPIError";
+		this.status = status;
+		this.details = details;
+	}
+}
+
+export interface GeminiVertexClient {
+	generateContent(
+		body: GenerateContentRequest,
+		options?: RequestOptions,
+	): Promise<GenerateContentResponse>;
+	countTokens(
+		body: CountTokensRequest,
+		options?: RequestOptions,
+	): Promise<CountTokensResponse>;
+	streamGenerateContent(
+		body: GenerateContentRequest,
+		options?: RequestOptions,
+	): AsyncIterable<StreamingResponseChunk>;
+}
+
+function trimTrailingSlash(url: string): string {
+	return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+function buildModelPath(
+	project: string,
+	location: string,
+	model: string,
+): string {
+	const encodedProject = encodeURIComponent(project);
+	const encodedLocation = encodeURIComponent(location);
+	const encodedModel = encodeURIComponent(model);
+	return `/v1/projects/${encodedProject}/locations/${encodedLocation}/publishers/google/models/${encodedModel}`;
+}
+
+async function parseJson<T>(response: Response): Promise<T> {
+	const text = await response.text();
+	if (!text) {
+		return {} as T;
+	}
+	try {
+		return JSON.parse(text) as T;
+	} catch (error) {
+		throw new GeminiVertexAPIError(
+			"Failed to parse JSON response",
+			response.status,
+			error instanceof Error ? { message: error.message } : undefined,
+		);
+	}
+}
+
+async function buildError(response: Response): Promise<GeminiVertexAPIError> {
+	let message = `Request failed with status ${response.status}`;
+	let details: unknown;
+	try {
+		const text = await response.text();
+		if (text) {
+			try {
+				const parsed = JSON.parse(text) as Record<string, unknown>;
+				details = parsed;
+				const errorPayload = (parsed as { error?: { message?: string } }).error;
+				if (errorPayload && typeof errorPayload.message === "string") {
+					message = errorPayload.message;
+				} else if (
+					typeof (parsed as { message?: string }).message === "string"
+				) {
+					message = (parsed as { message: string }).message;
+				} else {
+					message = text;
+				}
+			} catch {
+				message = text;
+			}
+		}
+	} catch {
+		// Ignore parsing failures and fall back to default message
+	}
+	return new GeminiVertexAPIError(message, response.status, details);
+}
+
+function applyHeaders(
+	baseHeaders: Headers,
+	extra?: Record<string, string>,
+): Headers {
+	if (!extra) return baseHeaders;
+	for (const [key, value] of Object.entries(extra)) {
+		baseHeaders.set(key, value);
+	}
+	return baseHeaders;
+}
+
+export function createGeminiVertexClient(
+	config: GeminiVertexClientConfig,
+): GeminiVertexClient {
+	const defaultBaseUrl = config.baseUrl
+		? trimTrailingSlash(config.baseUrl)
+		: undefined;
+	const http = config.fetch ?? fetch;
+
+	const resolveToken = (options?: RequestOptions) =>
+		options?.accessToken ?? config.accessToken;
+
+	const resolveBaseUrl = (options?: RequestOptions) => {
+		if (defaultBaseUrl) {
+			return defaultBaseUrl;
+		}
+		const locationForHost = options?.location ?? config.location;
+		return trimTrailingSlash(
+			`https://${locationForHost}-aiplatform.googleapis.com`,
+		);
+	};
+
+	const resolveHeaders = (options?: RequestOptions, acceptStream = false) => {
+		const headers = new Headers();
+		headers.set("Content-Type", "application/json");
+		applyHeaders(headers, options?.headers);
+		if (acceptStream) {
+			if (
+				!headers.has("Accept") ||
+				headers.get("Accept") === "application/json"
+			) {
+				headers.set("Accept", "application/x-ndjson");
+			}
+		} else if (!headers.has("Accept")) {
+			headers.set("Accept", "application/json");
+		}
+		const token = resolveToken(options);
+		if (token) {
+			headers.set("Authorization", `Bearer ${token}`);
+		}
+		return headers;
+	};
+
+	const resolveUrl = (options: RequestOptions | undefined, action: string) => {
+		const project = options?.project ?? config.project;
+		const location = options?.location ?? config.location;
+		const model = options?.model ?? config.model;
+		const path = buildModelPath(project, location, model);
+		return `${resolveBaseUrl(options)}${path}:${action}`;
+	};
+
+	const requestJson = async <T>(
+		action: string,
+		body: unknown,
+		options?: RequestOptions,
+	): Promise<T> => {
+		const url = resolveUrl(options, action);
+		const response = await http(url, {
+			method: "POST",
+			headers: resolveHeaders(options),
+			body: JSON.stringify(body ?? {}),
+			signal: options?.signal,
+		});
+		if (!response.ok) {
+			throw await buildError(response);
+		}
+		return parseJson<T>(response);
+	};
+
+	const requestStream = async (
+		action: string,
+		body: unknown,
+		options?: RequestOptions,
+	): Promise<Response> => {
+		const url = resolveUrl(options, action);
+		const response = await http(url, {
+			method: "POST",
+			headers: resolveHeaders(options, true),
+			body: JSON.stringify(body ?? {}),
+			signal: options?.signal,
+		});
+		if (!response.ok) {
+			throw await buildError(response);
+		}
+		return response;
+	};
+
+	return {
+		generateContent(body, options) {
+			return requestJson<GenerateContentResponse>(
+				"generateContent",
+				body,
+				options,
+			);
+		},
+		countTokens(body, options) {
+			return requestJson<CountTokensResponse>("countTokens", body, options);
+		},
+		async *streamGenerateContent(body, options) {
+			const response = await requestStream(
+				"streamGenerateContent",
+				body,
+				options,
+			);
+			const stream = response.body;
+			if (!stream) {
+				throw new GeminiVertexAPIError(
+					"Streaming response body is not available in this environment",
+					response.status,
+				);
+			}
+			const reader = stream.getReader();
+			const decoder = new TextDecoder();
+			let buffer = "";
+			try {
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) break;
+					buffer += decoder.decode(value, { stream: true });
+					let newlineIndex = buffer.indexOf("\n");
+					while (newlineIndex !== -1) {
+						let line = buffer.slice(0, newlineIndex).trim();
+						buffer = buffer.slice(newlineIndex + 1);
+						if (!line) {
+							newlineIndex = buffer.indexOf("\n");
+							continue;
+						}
+						if (line.startsWith("event:")) {
+							newlineIndex = buffer.indexOf("\n");
+							continue;
+						}
+						if (line.startsWith("data:")) {
+							line = line.slice(5).trim();
+						}
+						if (!line || line === "[DONE]") {
+							newlineIndex = buffer.indexOf("\n");
+							continue;
+						}
+						yield JSON.parse(line) as StreamingResponseChunk;
+						newlineIndex = buffer.indexOf("\n");
+					}
+				}
+				let remaining = buffer.trim();
+				if (remaining) {
+					if (remaining.startsWith("event:")) {
+						return;
+					}
+					if (remaining.startsWith("data:")) {
+						remaining = remaining.slice(5).trim();
+					}
+					if (remaining && remaining !== "[DONE]") {
+						yield JSON.parse(remaining) as StreamingResponseChunk;
+					}
+				}
+			} catch (error) {
+				if (error instanceof SyntaxError) {
+					throw new GeminiVertexAPIError(
+						"Failed to parse streamed response chunk",
+						response.status,
+						{ cause: error.message },
+					);
+				}
+				throw error;
+			} finally {
+				reader.releaseLock();
+			}
+		},
+	};
+}

--- a/app/api/gemini-vertix/sdk/index.ts
+++ b/app/api/gemini-vertix/sdk/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./client";

--- a/app/api/gemini-vertix/sdk/types.ts
+++ b/app/api/gemini-vertix/sdk/types.ts
@@ -1,0 +1,101 @@
+export interface InlineData {
+	mimeType: string;
+	data: string;
+}
+
+export interface FileData {
+	mimeType: string;
+	fileUri: string;
+}
+
+export interface FunctionCall {
+	name: string;
+	args?: Record<string, unknown>;
+}
+
+export interface FunctionResponse {
+	name: string;
+	response?: Record<string, unknown>;
+}
+
+export interface ContentPart {
+	text?: string;
+	inlineData?: InlineData;
+	fileData?: FileData;
+	functionCall?: FunctionCall;
+	functionResponse?: FunctionResponse;
+	[key: string]: unknown;
+}
+
+export interface Content {
+	role?: string;
+	parts: ContentPart[];
+	[key: string]: unknown;
+}
+
+export interface SafetySetting {
+	category?: string;
+	threshold?: string;
+}
+
+export interface GenerateContentRequest {
+	contents: Content[];
+	systemInstruction?: Content;
+	tools?: Record<string, unknown>[];
+	toolConfig?: Record<string, unknown>;
+	generationConfig?: Record<string, unknown>;
+	safetySettings?: SafetySetting[];
+	cachedContent?: string;
+	[key: string]: unknown;
+}
+
+export interface Candidate {
+	index?: number;
+	content?: Content;
+	finishReason?: string;
+	safetyRatings?: Record<string, unknown>[];
+	[key: string]: unknown;
+}
+
+export interface GenerateContentResponse {
+	candidates?: Candidate[];
+	usageMetadata?: Record<string, unknown>;
+	[key: string]: unknown;
+}
+
+export interface CountTokensRequest {
+	contents: Content[];
+	model?: string;
+	systemInstruction?: Content;
+	[key: string]: unknown;
+}
+
+export interface CountTokensResponse {
+	totalTokens?: number;
+	totalBillableTokens?: number;
+	modelVersion?: string;
+	[key: string]: unknown;
+}
+
+export interface StreamingResponseChunk {
+	candidates?: Array<{
+		content?: Content;
+		finishReason?: string;
+		[key: string]: unknown;
+	}>;
+	usageMetadata?: Record<string, unknown>;
+	[key: string]: unknown;
+}
+
+export interface VertexErrorPayload {
+	code?: number;
+	message: string;
+	status?: string;
+	details?: Record<string, unknown>[];
+	[key: string]: unknown;
+}
+
+export interface VertexError {
+	error: VertexErrorPayload;
+	[key: string]: unknown;
+}

--- a/app/api/gemini-vertix/stream-generate-content/route.ts
+++ b/app/api/gemini-vertix/stream-generate-content/route.ts
@@ -1,0 +1,58 @@
+import type { StreamingResponseChunk } from "../sdk";
+import { streamGenerateContent } from "../modules/stream-generate-content";
+
+function invalidJsonResponse(): Response {
+	return new Response(
+		JSON.stringify({ code: 400, message: "Invalid JSON body" }),
+		{
+			status: 400,
+			headers: { "Content-Type": "application/json" },
+		},
+	);
+}
+
+function toNdjsonStream(
+	iterable: AsyncIterable<StreamingResponseChunk>,
+): ReadableStream<Uint8Array> {
+	const encoder = new TextEncoder();
+	const iterator = iterable[Symbol.asyncIterator]();
+	return new ReadableStream<Uint8Array>({
+		async pull(controller) {
+			const { value, done } = await iterator.next();
+			if (done) {
+				controller.close();
+				return;
+			}
+			controller.enqueue(encoder.encode(`${JSON.stringify(value)}\n`));
+		},
+		async cancel(reason) {
+			if (iterator.return) {
+				await iterator.return(reason);
+			}
+		},
+	});
+}
+
+export async function POST(request: Request): Promise<Response> {
+	let payload: unknown;
+	try {
+		payload = await request.json();
+	} catch (error) {
+		console.error("Failed to parse streamGenerateContent request", error);
+		return invalidJsonResponse();
+	}
+
+	const result = await streamGenerateContent(payload);
+
+	if (!result.ok) {
+		return new Response(JSON.stringify(result.error), {
+			status: result.status,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+
+	return new Response(toNdjsonStream(result.stream), {
+		status: result.status,
+		headers: { "Content-Type": "application/x-ndjson" },
+	});
+}

--- a/app/api/gemini-vertix_docs/openapi_spec.json
+++ b/app/api/gemini-vertix_docs/openapi_spec.json
@@ -1,0 +1,339 @@
+{
+	"openapi": "3.1.0",
+	"info": {
+		"title": "Vertex Gemini API",
+		"version": "1.0.0",
+		"description": "OpenAPI specification for calling the Google Vertex AI Gemini endpoints used by the demo."
+	},
+	"servers": [
+		{
+			"url": "https://{location}-aiplatform.googleapis.com",
+			"variables": {
+				"location": {
+					"default": "us-central1",
+					"description": "Regional endpoint for Vertex AI."
+				}
+			}
+		}
+	],
+	"paths": {
+		"/v1/projects/{project}/locations/{location}/publishers/google/models/{model}:generateContent": {
+			"post": {
+				"operationId": "generateContent",
+				"summary": "Generate a response from a Gemini model.",
+				"parameters": [
+					{ "$ref": "#/components/parameters/project" },
+					{ "$ref": "#/components/parameters/location" },
+					{ "$ref": "#/components/parameters/model" }
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/GenerateContentRequest"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Generation succeeded.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/GenerateContentResponse"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error response",
+						"content": {
+							"application/json": {
+								"schema": { "$ref": "#/components/schemas/VertexError" }
+							}
+						}
+					}
+				}
+			}
+		},
+		"/v1/projects/{project}/locations/{location}/publishers/google/models/{model}:countTokens": {
+			"post": {
+				"operationId": "countTokens",
+				"summary": "Return token usage for a request payload.",
+				"parameters": [
+					{ "$ref": "#/components/parameters/project" },
+					{ "$ref": "#/components/parameters/location" },
+					{ "$ref": "#/components/parameters/model" }
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": { "$ref": "#/components/schemas/CountTokensRequest" }
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Token count computed.",
+						"content": {
+							"application/json": {
+								"schema": { "$ref": "#/components/schemas/CountTokensResponse" }
+							}
+						}
+					},
+					"default": {
+						"description": "Error response",
+						"content": {
+							"application/json": {
+								"schema": { "$ref": "#/components/schemas/VertexError" }
+							}
+						}
+					}
+				}
+			}
+		},
+		"/v1/projects/{project}/locations/{location}/publishers/google/models/{model}:streamGenerateContent": {
+			"post": {
+				"operationId": "streamGenerateContent",
+				"summary": "Stream chunks of a model response as newline delimited JSON.",
+				"parameters": [
+					{ "$ref": "#/components/parameters/project" },
+					{ "$ref": "#/components/parameters/location" },
+					{ "$ref": "#/components/parameters/model" }
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/GenerateContentRequest"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Stream of response chunks.",
+						"content": {
+							"application/x-ndjson": {
+								"schema": {
+									"$ref": "#/components/schemas/StreamingResponseChunk"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "Error response",
+						"content": {
+							"application/json": {
+								"schema": { "$ref": "#/components/schemas/VertexError" }
+							}
+						}
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"parameters": {
+			"project": {
+				"name": "project",
+				"in": "path",
+				"required": true,
+				"schema": { "type": "string" },
+				"description": "Google Cloud project id."
+			},
+			"location": {
+				"name": "location",
+				"in": "path",
+				"required": true,
+				"schema": { "type": "string" },
+				"description": "Vertex AI region."
+			},
+			"model": {
+				"name": "model",
+				"in": "path",
+				"required": true,
+				"schema": { "type": "string" },
+				"description": "Full model name, e.g. gemini-1.5-pro."
+			}
+		},
+		"schemas": {
+			"ContentPart": {
+				"type": "object",
+				"properties": {
+					"text": { "type": "string" },
+					"inlineData": {
+						"type": "object",
+						"properties": {
+							"mimeType": { "type": "string" },
+							"data": {
+								"type": "string",
+								"description": "Base64 encoded bytes."
+							}
+						},
+						"additionalProperties": false
+					},
+					"fileData": {
+						"type": "object",
+						"properties": {
+							"mimeType": { "type": "string" },
+							"fileUri": { "type": "string" }
+						},
+						"additionalProperties": false
+					},
+					"functionCall": {
+						"type": "object",
+						"properties": {
+							"name": { "type": "string" },
+							"args": { "type": "object", "additionalProperties": true }
+						},
+						"additionalProperties": false
+					},
+					"functionResponse": {
+						"type": "object",
+						"properties": {
+							"name": { "type": "string" },
+							"response": { "type": "object", "additionalProperties": true }
+						},
+						"additionalProperties": false
+					}
+				},
+				"additionalProperties": true
+			},
+			"Content": {
+				"type": "object",
+				"properties": {
+					"role": { "type": "string" },
+					"parts": {
+						"type": "array",
+						"items": { "$ref": "#/components/schemas/ContentPart" }
+					}
+				},
+				"required": ["parts"],
+				"additionalProperties": true
+			},
+			"SafetySetting": {
+				"type": "object",
+				"properties": {
+					"category": { "type": "string" },
+					"threshold": { "type": "string" }
+				},
+				"additionalProperties": false
+			},
+			"GenerateContentRequest": {
+				"type": "object",
+				"properties": {
+					"contents": {
+						"type": "array",
+						"items": { "$ref": "#/components/schemas/Content" }
+					},
+					"systemInstruction": { "$ref": "#/components/schemas/Content" },
+					"tools": {
+						"type": "array",
+						"items": { "type": "object", "additionalProperties": true }
+					},
+					"toolConfig": { "type": "object", "additionalProperties": true },
+					"generationConfig": {
+						"type": "object",
+						"additionalProperties": true
+					},
+					"safetySettings": {
+						"type": "array",
+						"items": { "$ref": "#/components/schemas/SafetySetting" }
+					},
+					"cachedContent": { "type": "string" }
+				},
+				"required": ["contents"],
+				"additionalProperties": true
+			},
+			"GenerateContentResponse": {
+				"type": "object",
+				"properties": {
+					"candidates": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"index": { "type": "integer" },
+								"content": { "$ref": "#/components/schemas/Content" },
+								"finishReason": { "type": "string" },
+								"safetyRatings": {
+									"type": "array",
+									"items": { "type": "object", "additionalProperties": true }
+								}
+							},
+							"additionalProperties": true
+						}
+					},
+					"usageMetadata": { "type": "object", "additionalProperties": true }
+				},
+				"additionalProperties": true
+			},
+			"CountTokensRequest": {
+				"type": "object",
+				"properties": {
+					"contents": {
+						"type": "array",
+						"items": { "$ref": "#/components/schemas/Content" }
+					},
+					"model": { "type": "string" },
+					"systemInstruction": { "$ref": "#/components/schemas/Content" }
+				},
+				"required": ["contents"],
+				"additionalProperties": true
+			},
+			"CountTokensResponse": {
+				"type": "object",
+				"properties": {
+					"totalTokens": { "type": "integer" },
+					"totalBillableTokens": { "type": "integer" },
+					"modelVersion": { "type": "string" }
+				},
+				"additionalProperties": true
+			},
+			"StreamingResponseChunk": {
+				"type": "object",
+				"properties": {
+					"candidates": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"content": { "$ref": "#/components/schemas/Content" },
+								"finishReason": { "type": "string" }
+							},
+							"additionalProperties": true
+						}
+					},
+					"usageMetadata": { "type": "object", "additionalProperties": true }
+				},
+				"additionalProperties": true
+			},
+			"VertexError": {
+				"type": "object",
+				"properties": {
+					"error": {
+						"type": "object",
+						"properties": {
+							"code": { "type": "integer" },
+							"message": { "type": "string" },
+							"status": { "type": "string" },
+							"details": {
+								"type": "array",
+								"items": { "type": "object", "additionalProperties": true }
+							}
+						},
+						"required": ["message"],
+						"additionalProperties": true
+					}
+				},
+				"required": ["error"],
+				"additionalProperties": true
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add per-endpoint Gemini Vertex module wrappers that build clients from env configuration and normalise SDK responses
- share validation and error helpers to reuse configuration, request parsing, and error mapping across the modules
- cover the new modules with Vitest cases for success, streaming, and error flows
- expose Next.js route handlers for each Gemini Vertex endpoint, including NDJSON streaming conversion for streamGenerateContent
- add API route Vitest coverage to assert happy-path responses, error propagation, and invalid JSON handling

## Testing
- pnpm vitest run --environment node app/api/gemini-vertix/_tests/routes.test.ts
- pnpm vitest run --environment node app/api/gemini-vertix/_tests/modules.test.ts
- pnpm vitest run --environment node app/api/gemini-vertix/_tests/client.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5b549997083299f1d1f7c64bfa90c