### PR TITLE
Add Vertex proxy SDK and modules

### DIFF
--- a/app/api/gemini-vertix/vertix/__tests__/modules.test.ts
+++ b/app/api/gemini-vertix/vertix/__tests__/modules.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+	CountTokensRequest,
+	GenerateContentRequest,
+	StreamingResponseChunk,
+} from "../../sdk";
+import { countTokens } from "../modules/count-tokens";
+import { generateContent } from "../modules/generate-content";
+import { streamGenerateContent } from "../modules/stream-generate-content";
+
+declare const ReadableStream: typeof globalThis.ReadableStream;
+
+describe("Vertex proxy modules", () => {
+	const baseRequest: GenerateContentRequest = {
+		contents: [
+			{
+				parts: [{ text: "Hello" }],
+			},
+		],
+	};
+
+	const baseCountRequest: CountTokensRequest = {
+		contents: baseRequest.contents,
+	};
+
+	const envKeys = [
+		"GEMINI_VERTEX_PROJECT",
+		"GEMINI_VERTEX_LOCATION",
+		"GEMINI_VERTEX_MODEL",
+	];
+
+	const originalEnv: Record<string, string | undefined> = {};
+
+	beforeEach(() => {
+		envKeys.forEach((key) => {
+			originalEnv[key] = process.env[key];
+		});
+		process.env.GEMINI_VERTEX_PROJECT = "demo-project";
+		process.env.GEMINI_VERTEX_LOCATION = "us-central1";
+		process.env.GEMINI_VERTEX_MODEL = "gemini-1.5-pro";
+	});
+
+	afterEach(() => {
+		envKeys.forEach((key) => {
+			if (originalEnv[key] === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = originalEnv[key];
+			}
+		});
+		vi.restoreAllMocks();
+	});
+
+	it("delegates generateContent through the proxy client", async () => {
+		const payload = { candidates: [{ index: 0 }] };
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify(payload), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+
+		const result = await generateContent(baseRequest, {
+			clientConfig: {
+				fetch: fetchMock as unknown as typeof fetch,
+			},
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchMock.mock.calls[0] ?? [];
+		expect(url).toContain(
+			"/api/gemini-vertix/vertix/v1/projects/demo-project/locations/us-central1/publishers/google/models/gemini-1.5-pro:generateContent",
+		);
+		expect(init?.method).toBe("POST");
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.status).toBe(200);
+			expect(result.data).toEqual(payload);
+		}
+	});
+
+	it("delegates countTokens requests", async () => {
+		const payload = { totalTokens: 12 };
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify(payload), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+
+		const result = await countTokens(baseCountRequest, {
+			clientConfig: {
+				fetch: fetchMock as unknown as typeof fetch,
+			},
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url] = fetchMock.mock.calls[0] ?? [];
+		expect(url).toContain(":countTokens");
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toEqual(payload);
+		}
+	});
+
+	it("returns a stream iterator for streamGenerateContent", async () => {
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(
+					encoder.encode(`${JSON.stringify({ candidates: [{ index: 0 }] })}\n`),
+				);
+				controller.close();
+			},
+		});
+
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(stream, {
+				status: 200,
+				headers: { "Content-Type": "application/x-ndjson" },
+			}),
+		);
+
+		const result = await streamGenerateContent(baseRequest, {
+			clientConfig: {
+				fetch: fetchMock as unknown as typeof fetch,
+			},
+		});
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			const chunks: StreamingResponseChunk[] = [];
+			for await (const chunk of result.stream) {
+				chunks.push(chunk);
+			}
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			expect(chunks).toHaveLength(1);
+			expect(chunks[0]).toMatchObject({ candidates: [{ index: 0 }] });
+		}
+	});
+
+	it("normalises VertexProxyAPIError instances", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					error: {
+						code: 403,
+						message: "Forbidden",
+						status: "PERMISSION_DENIED",
+					},
+				}),
+				{
+					status: 403,
+					headers: { "Content-Type": "application/json" },
+				},
+			),
+		);
+
+		const result = await generateContent(baseRequest, {
+			clientConfig: {
+				fetch: fetchMock as unknown as typeof fetch,
+			},
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.status).toBe(403);
+			expect(result.error).toMatchObject({
+				code: 403,
+				message: "Forbidden",
+				status: "PERMISSION_DENIED",
+			});
+		}
+	});
+
+	it("returns a 400 error when validation fails", async () => {
+		const invalidPayload = { contents: null } as unknown;
+
+		const result = await generateContent(invalidPayload, {
+			clientConfig: {
+				fetch: vi.fn(),
+			},
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.status).toBe(400);
+			expect(result.error.message).toContain("contents");
+		}
+	});
+});

--- a/app/api/gemini-vertix/vertix/modules/count-tokens.ts
+++ b/app/api/gemini-vertix/vertix/modules/count-tokens.ts
@@ -1,0 +1,27 @@
+import type { CountTokensResponse } from "../sdk";
+import {
+	ModuleError,
+	ModuleOptions,
+	ModuleSuccess,
+	normaliseError,
+	splitModuleOptions,
+	validateCountTokensRequest,
+} from "./shared";
+
+export type CountTokensResult =
+	| ModuleSuccess<CountTokensResponse>
+	| ModuleError;
+
+export async function countTokens(
+	payload: unknown,
+	options?: ModuleOptions,
+): Promise<CountTokensResult> {
+	try {
+		const body = validateCountTokensRequest(payload);
+		const { client, requestOptions } = splitModuleOptions(options);
+		const data = await client.countTokens(body, requestOptions);
+		return { ok: true, status: 200, data };
+	} catch (error) {
+		return normaliseError(error);
+	}
+}

--- a/app/api/gemini-vertix/vertix/modules/generate-content.ts
+++ b/app/api/gemini-vertix/vertix/modules/generate-content.ts
@@ -1,0 +1,27 @@
+import type { GenerateContentResponse } from "../sdk";
+import {
+	ModuleError,
+	ModuleOptions,
+	ModuleSuccess,
+	normaliseError,
+	splitModuleOptions,
+	validateGenerateContentRequest,
+} from "./shared";
+
+export type GenerateContentResult =
+	| ModuleSuccess<GenerateContentResponse>
+	| ModuleError;
+
+export async function generateContent(
+	payload: unknown,
+	options?: ModuleOptions,
+): Promise<GenerateContentResult> {
+	try {
+		const body = validateGenerateContentRequest(payload);
+		const { client, requestOptions } = splitModuleOptions(options);
+		const data = await client.generateContent(body, requestOptions);
+		return { ok: true, status: 200, data };
+	} catch (error) {
+		return normaliseError(error);
+	}
+}

--- a/app/api/gemini-vertix/vertix/modules/shared.ts
+++ b/app/api/gemini-vertix/vertix/modules/shared.ts
@@ -1,0 +1,218 @@
+import {
+	createVertexProxyClient,
+	VertexProxyAPIError,
+	type VertexProxyClient,
+	type VertexProxyClientConfig,
+	type VertexProxyRequestOptions,
+} from "../sdk";
+import type {
+	CountTokensRequest,
+	GenerateContentRequest,
+	StreamingResponseChunk,
+	VertexErrorPayload,
+} from "../sdk";
+import {
+	validateCountTokensRequest as baseValidateCountTokensRequest,
+	validateGenerateContentRequest as baseValidateGenerateContentRequest,
+} from "../../modules/shared";
+
+const ENV_KEYS = {
+	project: [
+		"GEMINI_VERTEX_PROJECT",
+		"VERTEX_GEMINI_PROJECT",
+		"GOOGLE_VERTEX_PROJECT",
+	],
+	location: [
+		"GEMINI_VERTEX_LOCATION",
+		"VERTEX_GEMINI_LOCATION",
+		"GOOGLE_VERTEX_LOCATION",
+	],
+	model: ["GEMINI_VERTEX_MODEL", "VERTEX_GEMINI_MODEL", "GOOGLE_VERTEX_MODEL"],
+	baseUrl: [
+		"NEXT_PUBLIC_GEMINI_VERTEX_PROXY_BASE_URL",
+		"NEXT_PUBLIC_VERTEX_GEMINI_PROXY_BASE_URL",
+		"NEXT_PUBLIC_GOOGLE_VERTEX_PROXY_BASE_URL",
+		"GEMINI_VERTEX_PROXY_BASE_URL",
+		"VERTEX_PROXY_BASE_URL",
+	],
+} as const;
+
+export interface ModuleOptions extends VertexProxyRequestOptions {
+	clientConfig?: Partial<VertexProxyClientConfig>;
+}
+
+export interface ModuleSuccess<T> {
+	ok: true;
+	status: number;
+	data: T;
+}
+
+export interface ModuleStreamSuccess {
+	ok: true;
+	status: number;
+	stream: AsyncIterable<StreamingResponseChunk>;
+}
+
+export interface ModuleError {
+	ok: false;
+	status: number;
+	error: VertexErrorPayload;
+}
+
+class RequestValidationError extends Error {
+	readonly status: number;
+
+	constructor(message: string, status = 400) {
+		super(message);
+		this.name = "ValidationError";
+		this.status = status;
+	}
+}
+
+function readEnv(keys: readonly string[]): string | undefined {
+	for (const key of keys) {
+		const value = process.env[key];
+		if (value) return value;
+	}
+	return undefined;
+}
+
+function ensureValue(value: string | undefined, label: string): string {
+	if (!value) {
+		throw new RequestValidationError(
+			`Missing Vertex proxy configuration: ${label}`,
+			500,
+		);
+	}
+	return value;
+}
+
+function mergeClientConfig(
+	overrides?: Partial<VertexProxyClientConfig>,
+): VertexProxyClientConfig {
+	const project = overrides?.project ?? readEnv(ENV_KEYS.project);
+	const location = overrides?.location ?? readEnv(ENV_KEYS.location);
+	const model = overrides?.model ?? readEnv(ENV_KEYS.model);
+
+	const config: VertexProxyClientConfig = {
+		project: ensureValue(project, "project"),
+		location: ensureValue(location, "location"),
+		model: ensureValue(model, "model"),
+	};
+
+	const baseUrl = overrides?.baseUrl ?? readEnv(ENV_KEYS.baseUrl);
+	if (baseUrl) {
+		config.baseUrl = baseUrl;
+	}
+
+	if (overrides?.fetch) {
+		config.fetch = overrides.fetch;
+	}
+
+	if (overrides?.defaultHeaders) {
+		config.defaultHeaders = overrides.defaultHeaders;
+	}
+
+	return config;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function extractVertexError(
+	details: unknown,
+	fallback: number,
+	message: string,
+): VertexErrorPayload {
+	if (isRecord(details) && isRecord(details.error)) {
+		const error = details.error as VertexErrorPayload;
+		return {
+			code: error.code ?? fallback,
+			message: error.message ?? message,
+			status: error.status,
+			details: error.details,
+		};
+	}
+	if (Array.isArray(details)) {
+		return {
+			code: fallback,
+			message,
+			details: details as Record<string, unknown>[],
+		};
+	}
+	if (isRecord(details)) {
+		return {
+			code: fallback,
+			message,
+			details: [details as Record<string, unknown>],
+		};
+	}
+	return { code: fallback, message };
+}
+
+function isValidationError(
+	error: unknown,
+): error is Error & { status?: number } {
+	return error instanceof Error && error.name === "ValidationError";
+}
+
+function validationStatus(error: Error & { status?: number }): number {
+	return typeof error.status === "number" ? error.status : 400;
+}
+
+export function validateGenerateContentRequest(
+	payload: unknown,
+): GenerateContentRequest {
+	return baseValidateGenerateContentRequest(payload);
+}
+
+export function validateCountTokensRequest(
+	payload: unknown,
+): CountTokensRequest {
+	return baseValidateCountTokensRequest(payload);
+}
+
+export function normaliseError(error: unknown): ModuleError {
+	if (isValidationError(error)) {
+		const status = validationStatus(error);
+		return {
+			ok: false,
+			status,
+			error: {
+				code: status,
+				message: error.message,
+			},
+		};
+	}
+	if (error instanceof VertexProxyAPIError) {
+		return {
+			ok: false,
+			status: error.status,
+			error: extractVertexError(error.details, error.status, error.message),
+		};
+	}
+	throw error;
+}
+
+export function createClient(
+	options?: Partial<VertexProxyClientConfig>,
+): VertexProxyClient {
+	const config = mergeClientConfig(options);
+	return createVertexProxyClient(config);
+}
+
+export function splitModuleOptions(options?: ModuleOptions): {
+	client: VertexProxyClient;
+	requestOptions: VertexProxyRequestOptions | undefined;
+} {
+	const clientOverrides = options?.clientConfig;
+	const client = createClient(clientOverrides);
+	const { clientConfig, ...requestOptions } = options ?? {};
+	const request: VertexProxyRequestOptions | undefined = Object.keys(
+		requestOptions,
+	).length
+		? (requestOptions as VertexProxyRequestOptions)
+		: undefined;
+	return { client, requestOptions: request };
+}

--- a/app/api/gemini-vertix/vertix/modules/stream-generate-content.ts
+++ b/app/api/gemini-vertix/vertix/modules/stream-generate-content.ts
@@ -1,0 +1,24 @@
+import {
+	ModuleError,
+	ModuleOptions,
+	ModuleStreamSuccess,
+	normaliseError,
+	splitModuleOptions,
+	validateGenerateContentRequest,
+} from "./shared";
+
+export type StreamGenerateContentResult = ModuleStreamSuccess | ModuleError;
+
+export async function streamGenerateContent(
+	payload: unknown,
+	options?: ModuleOptions,
+): Promise<StreamGenerateContentResult> {
+	try {
+		const body = validateGenerateContentRequest(payload);
+		const { client, requestOptions } = splitModuleOptions(options);
+		const stream = client.streamGenerateContent(body, requestOptions);
+		return { ok: true, status: 200, stream };
+	} catch (error) {
+		return normaliseError(error);
+	}
+}

--- a/app/api/gemini-vertix/vertix/sdk/client.ts
+++ b/app/api/gemini-vertix/vertix/sdk/client.ts
@@ -1,0 +1,299 @@
+import type {
+	CountTokensRequest,
+	CountTokensResponse,
+	GenerateContentRequest,
+	GenerateContentResponse,
+	StreamingResponseChunk,
+} from "./types";
+
+const DEFAULT_PROXY_BASE_URL = "/api/gemini-vertix/vertix";
+
+export interface VertexProxyClientConfig {
+	project: string;
+	location: string;
+	model: string;
+	baseUrl?: string;
+	fetch?: typeof fetch;
+	defaultHeaders?: Record<string, string>;
+}
+
+export interface VertexProxyRequestOptions {
+	project?: string;
+	location?: string;
+	model?: string;
+	endpoint?: string;
+	region?: string;
+	accessToken?: string;
+	apiKey?: string;
+	userProject?: string;
+	headers?: Record<string, string>;
+	signal?: AbortSignal;
+}
+
+export class VertexProxyAPIError extends Error {
+	readonly status: number;
+	readonly details?: unknown;
+
+	constructor(message: string, status: number, details?: unknown) {
+		super(message);
+		this.name = "VertexProxyAPIError";
+		this.status = status;
+		this.details = details;
+	}
+}
+
+export interface VertexProxyClient {
+	generateContent(
+		body: GenerateContentRequest,
+		options?: VertexProxyRequestOptions,
+	): Promise<GenerateContentResponse>;
+	countTokens(
+		body: CountTokensRequest,
+		options?: VertexProxyRequestOptions,
+	): Promise<CountTokensResponse>;
+	streamGenerateContent(
+		body: GenerateContentRequest,
+		options?: VertexProxyRequestOptions,
+	): AsyncIterable<StreamingResponseChunk>;
+}
+
+function trimTrailingSlash(url: string): string {
+	return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+function buildModelPath(
+	project: string,
+	location: string,
+	model: string,
+): string {
+	const encodedProject = encodeURIComponent(project);
+	const encodedLocation = encodeURIComponent(location);
+	const encodedModel = encodeURIComponent(model);
+	return `/v1/projects/${encodedProject}/locations/${encodedLocation}/publishers/google/models/${encodedModel}`;
+}
+
+async function parseJson<T>(response: Response): Promise<T> {
+	const text = await response.text();
+	if (!text) {
+		return {} as T;
+	}
+	try {
+		return JSON.parse(text) as T;
+	} catch (error) {
+		throw new VertexProxyAPIError(
+			"Failed to parse JSON response",
+			response.status,
+			error instanceof Error ? { message: error.message } : undefined,
+		);
+	}
+}
+
+async function buildError(response: Response): Promise<VertexProxyAPIError> {
+	let message = `Request failed with status ${response.status}`;
+	let details: unknown;
+	try {
+		const text = await response.text();
+		if (text) {
+			try {
+				const parsed = JSON.parse(text) as Record<string, unknown>;
+				details = parsed;
+				const errorPayload = (parsed as { error?: { message?: string } }).error;
+				if (errorPayload && typeof errorPayload.message === "string") {
+					message = errorPayload.message;
+				} else if (
+					typeof (parsed as { message?: string }).message === "string"
+				) {
+					message = (parsed as { message: string }).message;
+				} else {
+					message = text;
+				}
+			} catch {
+				message = text;
+			}
+		}
+	} catch {
+		// Ignore parsing failures and fall back to the default message.
+	}
+	return new VertexProxyAPIError(message, response.status, details);
+}
+
+function applyHeaders(target: Headers, additions?: Record<string, string>) {
+	if (!additions) return;
+	for (const [key, value] of Object.entries(additions)) {
+		target.set(key, value);
+	}
+}
+
+function buildHeaders(
+	config: VertexProxyClientConfig,
+	options: VertexProxyRequestOptions | undefined,
+	acceptStream = false,
+): Headers {
+	const headers = new Headers(config.defaultHeaders);
+	if (!headers.has("Content-Type")) {
+		headers.set("Content-Type", "application/json");
+	}
+	if (acceptStream) {
+		if (!headers.has("Accept")) {
+			headers.set("Accept", "application/x-ndjson");
+		}
+	} else if (!headers.has("Accept")) {
+		headers.set("Accept", "application/json");
+	}
+	applyHeaders(headers, options?.headers);
+
+	if (options?.endpoint && !headers.has("x-vertex-endpoint")) {
+		headers.set("x-vertex-endpoint", options.endpoint);
+	}
+	if (options?.region && !headers.has("x-vertex-region")) {
+		headers.set("x-vertex-region", options.region);
+	}
+	if (options?.apiKey && !headers.has("x-goog-api-key")) {
+		headers.set("x-goog-api-key", options.apiKey);
+	}
+	if (options?.userProject && !headers.has("x-goog-user-project")) {
+		headers.set("x-goog-user-project", options.userProject);
+	}
+	if (options?.accessToken && !headers.has("authorization")) {
+		headers.set("authorization", `Bearer ${options.accessToken}`);
+	}
+	return headers;
+}
+
+export function createVertexProxyClient(
+	config: VertexProxyClientConfig,
+): VertexProxyClient {
+	const http = config.fetch ?? fetch;
+	const baseUrl = trimTrailingSlash(config.baseUrl ?? DEFAULT_PROXY_BASE_URL);
+
+	const resolveUrl = (
+		options: VertexProxyRequestOptions | undefined,
+		action: string,
+	) => {
+		const project = options?.project ?? config.project;
+		const location = options?.location ?? config.location;
+		const model = options?.model ?? config.model;
+		const path = buildModelPath(project, location, model);
+		return `${baseUrl}${path}:${action}`;
+	};
+
+	const requestJson = async <T>(
+		action: string,
+		body: unknown,
+		options?: VertexProxyRequestOptions,
+	): Promise<T> => {
+		const url = resolveUrl(options, action);
+		const response = await http(url, {
+			method: "POST",
+			headers: buildHeaders(config, options),
+			body: JSON.stringify(body ?? {}),
+			signal: options?.signal,
+		});
+		if (!response.ok) {
+			throw await buildError(response);
+		}
+		return parseJson<T>(response);
+	};
+
+	const requestStream = async (
+		action: string,
+		body: unknown,
+		options?: VertexProxyRequestOptions,
+	): Promise<Response> => {
+		const url = resolveUrl(options, action);
+		const response = await http(url, {
+			method: "POST",
+			headers: buildHeaders(config, options, true),
+			body: JSON.stringify(body ?? {}),
+			signal: options?.signal,
+		});
+		if (!response.ok) {
+			throw await buildError(response);
+		}
+		return response;
+	};
+
+	return {
+		generateContent(body, options) {
+			return requestJson<GenerateContentResponse>(
+				"generateContent",
+				body,
+				options,
+			);
+		},
+		countTokens(body, options) {
+			return requestJson<CountTokensResponse>("countTokens", body, options);
+		},
+		async *streamGenerateContent(body, options) {
+			const response = await requestStream(
+				"streamGenerateContent",
+				body,
+				options,
+			);
+			const stream = response.body;
+			if (!stream) {
+				throw new VertexProxyAPIError(
+					"Streaming response body is not available in this environment",
+					response.status,
+				);
+			}
+			const reader = stream.getReader();
+			const decoder = new TextDecoder();
+			let buffer = "";
+			try {
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) break;
+					buffer += decoder.decode(value, { stream: true });
+					let newlineIndex = buffer.indexOf("\n");
+					while (newlineIndex !== -1) {
+						let line = buffer.slice(0, newlineIndex).trim();
+						buffer = buffer.slice(newlineIndex + 1);
+						if (!line) {
+							newlineIndex = buffer.indexOf("\n");
+							continue;
+						}
+						if (line.startsWith("event:")) {
+							newlineIndex = buffer.indexOf("\n");
+							continue;
+						}
+						if (line.startsWith("data:")) {
+							line = line.slice(5).trim();
+						}
+						if (!line || line === "[DONE]") {
+							newlineIndex = buffer.indexOf("\n");
+							continue;
+						}
+						yield JSON.parse(line) as StreamingResponseChunk;
+						newlineIndex = buffer.indexOf("\n");
+					}
+				}
+				let remaining = buffer.trim();
+				if (remaining) {
+					if (remaining.startsWith("event:")) {
+						return;
+					}
+					if (remaining.startsWith("data:")) {
+						remaining = remaining.slice(5).trim();
+					}
+					if (remaining && remaining !== "[DONE]") {
+						yield JSON.parse(remaining) as StreamingResponseChunk;
+					}
+				}
+			} catch (error) {
+				if (error instanceof SyntaxError) {
+					throw new VertexProxyAPIError(
+						"Failed to parse streamed response chunk",
+						response.status,
+						{ cause: error.message },
+					);
+				}
+				throw error;
+			} finally {
+				reader.releaseLock();
+			}
+		},
+	};
+}
+
+export { DEFAULT_PROXY_BASE_URL };

--- a/app/api/gemini-vertix/vertix/sdk/index.ts
+++ b/app/api/gemini-vertix/vertix/sdk/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./client";

--- a/app/api/gemini-vertix/vertix/sdk/types.ts
+++ b/app/api/gemini-vertix/vertix/sdk/types.ts
@@ -1,0 +1,17 @@
+export type {
+	Candidate,
+	Content,
+	ContentPart,
+	CountTokensRequest,
+	CountTokensResponse,
+	FileData,
+	FunctionCall,
+	FunctionResponse,
+	GenerateContentRequest,
+	GenerateContentResponse,
+	InlineData,
+	SafetySetting,
+	StreamingResponseChunk,
+	VertexError,
+	VertexErrorPayload,
+} from "../../sdk";


### PR DESCRIPTION
## Summary
- add a Vertex proxy SDK that targets the local /api/gemini-vertix/vertix proxy and exposes generate, count, and stream helpers
- add module wrappers that validate input, resolve configuration, and call the proxy client for each Vertex capability
- cover the new proxy modules with vitest cases for success paths and error handling

## Testing
- pnpm test *(fails: lib/services/_tests/mcpConnection.test.ts requires unavailable MCP tool)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c2a150f083298b08411fcbf9da06