### PR TITLE
feat(openai): implement universal route proxy

### DIFF
--- a/app/api/open-ai/[[...path]]/route.ts
+++ b/app/api/open-ai/[[...path]]/route.ts
@@ -1,0 +1,137 @@
+import { OpenAIClient, OpenAIHttpError } from "../sdk/openai-client";
+import type { HttpMethod } from "../modules/operation-registry";
+import {
+	buildErrorResponse,
+	buildHeaderOverrides,
+	buildQuery,
+	forwardResponse,
+	jsonErrorResponse,
+	readRequestBody,
+} from "../route-support";
+
+type RouteContext = { params: { path?: string[] } };
+
+let cachedClient: OpenAIClient | null = null;
+let cachedSignature: string | null = null;
+
+export const GET = createHandler("get");
+export const POST = createHandler("post");
+export const PUT = createHandler("put");
+export const PATCH = createHandler("patch");
+export const DELETE = createHandler("delete");
+export const OPTIONS = createHandler("options");
+export const HEAD = createHandler("head");
+export const TRACE = createHandler("trace");
+
+async function handleRequest(
+	method: HttpMethod,
+	request: Request,
+	context: RouteContext,
+): Promise<Response> {
+	const apiKey = process.env.OPENAI_API_KEY;
+
+	if (!apiKey) {
+		return jsonErrorResponse(
+			500,
+			"OpenAI API key is not configured on the server.",
+		);
+	}
+
+	const segments = context.params.path ?? [];
+	const path = `/${segments.join("/")}`.replace(/\/+/g, "/");
+
+	try {
+		const client = await getClient(apiKey);
+		const resolved = await client.resolveOperation(method, path);
+
+		if (!resolved) {
+			return jsonErrorResponse(
+				404,
+				`No OpenAI operation mapped for ${method.toUpperCase()} ${path}`,
+			);
+		}
+
+		const url = new URL(request.url);
+		const query = buildQuery(url.searchParams);
+		const headers = buildHeaderOverrides(
+			resolved.operation.parameters,
+			request.headers,
+		);
+
+		let body: unknown;
+
+		try {
+			body = await readRequestBody(method, request);
+		} catch (error) {
+			console.error("Failed to read OpenAI request body", error);
+			return jsonErrorResponse(400, "Invalid request body payload.");
+		}
+
+		try {
+			const response = await client.callRaw(resolved.operation.id, {
+				pathParams: resolved.pathParams,
+				query,
+				headers,
+				body,
+			});
+
+			return forwardResponse(response);
+		} catch (error) {
+			if (error instanceof OpenAIHttpError) {
+				return buildErrorResponse(error);
+			}
+
+			console.error("Unexpected error proxying OpenAI request", error);
+			return jsonErrorResponse(500, "Unexpected OpenAI proxy error");
+		}
+	} catch (error) {
+		if (error instanceof Response) {
+			return error;
+		}
+
+		console.error("Failed to process OpenAI route request", error);
+		return jsonErrorResponse(500, "Failed to process OpenAI request");
+	}
+}
+
+function createHandler(method: HttpMethod) {
+	return (request: Request, context: RouteContext): Promise<Response> =>
+		handleRequest(method, request, context);
+}
+
+async function getClient(apiKey: string): Promise<OpenAIClient> {
+	const baseUrl =
+		process.env.OPENAI_API_BASE_URL ?? "https://api.openai.com/v1";
+	const defaultHeaders: Record<string, string> = {};
+
+	if (process.env.OPENAI_ORGANIZATION) {
+		defaultHeaders["OpenAI-Organization"] = process.env.OPENAI_ORGANIZATION;
+	}
+
+	if (process.env.OPENAI_PROJECT) {
+		defaultHeaders["OpenAI-Project"] = process.env.OPENAI_PROJECT;
+	}
+
+	if (process.env.OPENAI_BETA) {
+		defaultHeaders["OpenAI-Beta"] = process.env.OPENAI_BETA;
+	}
+
+	if (process.env.OPENAI_USER) {
+		defaultHeaders["OpenAI-User"] = process.env.OPENAI_USER;
+	}
+
+	const signature = JSON.stringify({ apiKey, baseUrl, defaultHeaders });
+
+	if (!cachedClient || cachedSignature !== signature) {
+		cachedClient = new OpenAIClient({
+			apiKey,
+			baseUrl,
+			defaultHeaders: Object.keys(defaultHeaders).length
+				? defaultHeaders
+				: undefined,
+		});
+		cachedSignature = signature;
+	}
+
+	return cachedClient;
+}

--- a/app/api/open-ai/modules/__tests__/registry.test.ts
+++ b/app/api/open-ai/modules/__tests__/registry.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, beforeEach } from "vitest";
+
+import {
+	buildOperationRegistry,
+	matchOperationByPath,
+} from "../operation-registry";
+import { loadOpenAISpec, resetOpenAISpecCache } from "../spec-loader";
+import { OpenAIClient } from "../../sdk/openai-client";
+
+const LIST_ASSISTANTS_OPERATION = "listAssistants";
+
+describe("OpenAI modular SDK", () => {
+	beforeEach(() => {
+		resetOpenAISpecCache();
+	});
+
+	it("builds a registry containing documented operations", async () => {
+		const spec = await loadOpenAISpec();
+		const registry = buildOperationRegistry(spec);
+
+		expect(registry.byId.has(LIST_ASSISTANTS_OPERATION)).toBe(true);
+	});
+
+	it("exposes modules grouped by tag", async () => {
+		const client = new OpenAIClient({ apiKey: "test" });
+		const modules = await client.modules();
+
+		expect(modules.assistants).toBeDefined();
+		expect(modules.assistants.tag).toBe("Assistants");
+		expect(typeof modules.assistants[LIST_ASSISTANTS_OPERATION]).toBe(
+			"function",
+		);
+	});
+
+	it("throws when calling unknown operations", async () => {
+		const client = new OpenAIClient({ apiKey: "test" });
+
+		await expect(client.call("unknownOperation")).rejects.toThrow(
+			/Unknown OpenAI operation/,
+		);
+	});
+
+	it("matches operations by method and path", async () => {
+		const spec = await loadOpenAISpec();
+		const registry = buildOperationRegistry(spec);
+
+		const rootMatch = matchOperationByPath(registry, "get", "/assistants");
+		expect(rootMatch?.operation.id).toBe(LIST_ASSISTANTS_OPERATION);
+
+		const paramMatch = matchOperationByPath(
+			registry,
+			"get",
+			"/assistants/asst_123",
+		);
+
+		expect(paramMatch?.operation.id).toBe("getAssistant");
+		expect(paramMatch?.pathParams).toEqual({ assistant_id: "asst_123" });
+	});
+
+	it("resolves operations from the client by path", async () => {
+		const client = new OpenAIClient({ apiKey: "test" });
+
+		const resolved = await client.resolveOperation(
+			"get",
+			"/assistants/asst_abc123",
+		);
+
+		expect(resolved?.operation.id).toBe("getAssistant");
+		expect(resolved?.pathParams.assistant_id).toBe("asst_abc123");
+	});
+});

--- a/app/api/open-ai/modules/http-client.ts
+++ b/app/api/open-ai/modules/http-client.ts
@@ -1,0 +1,202 @@
+import { URLSearchParams } from "node:url";
+
+import type { HttpMethod } from "./operation-registry";
+import { isPlainObject } from "./utils";
+
+const JSON_CONTENT_TYPE = "application/json";
+
+export interface HttpClientConfig {
+	readonly baseUrl: string;
+	readonly apiKey: string;
+	readonly defaultHeaders?: Record<string, string>;
+}
+
+export interface RequestOptions {
+	readonly method: HttpMethod;
+	readonly path: string;
+	readonly query?: Record<string, unknown>;
+	readonly headers?: Record<string, string>;
+	readonly body?: unknown;
+	readonly signal?: AbortSignal;
+}
+
+export class HttpClient {
+	private readonly baseUrl: string;
+	private readonly apiKey: string;
+	private readonly defaultHeaders: Record<string, string>;
+
+	constructor(config: HttpClientConfig) {
+		this.baseUrl = config.baseUrl;
+		this.apiKey = config.apiKey;
+		this.defaultHeaders = config.defaultHeaders ?? {};
+	}
+
+	async request<T = unknown>(options: RequestOptions): Promise<T> {
+		const response = await this.requestRaw(options);
+		return this.parseResponse<T>(response);
+	}
+
+	async requestRaw({
+		method,
+		path,
+		query,
+		headers,
+		body,
+		signal,
+	}: RequestOptions): Promise<Response> {
+		const url = this.composeUrl(path, query);
+		const composedHeaders = this.composeHeaders(headers, body);
+		const response = await fetch(url, {
+			method: method.toUpperCase(),
+			headers: composedHeaders,
+			body: this.serializeBody(body, composedHeaders.get("content-type")),
+			signal,
+		});
+
+		if (!response.ok) {
+			const errorBody = await safeReadResponse(response.clone());
+			throw new OpenAIHttpError(
+				response.status,
+				response.statusText,
+				errorBody,
+				new Headers(response.headers),
+			);
+		}
+
+		return response;
+	}
+
+	async parseResponse<T = unknown>(response: Response): Promise<T> {
+		return (await safeReadResponse(response)) as T;
+	}
+
+	private composeUrl(path: string, query?: Record<string, unknown>): string {
+		const url = new URL(
+			path,
+			this.baseUrl.endsWith("/") ? this.baseUrl : `${this.baseUrl}/`,
+		);
+
+		if (query && Object.keys(query).length > 0) {
+			const params = new URLSearchParams();
+			for (const [key, value] of Object.entries(query)) {
+				if (value === undefined || value === null) {
+					continue;
+				}
+
+				if (Array.isArray(value)) {
+					for (const item of value) {
+						params.append(key, String(item));
+					}
+				} else {
+					params.append(key, String(value));
+				}
+			}
+
+			url.search = params.toString();
+		}
+
+		return url.toString();
+	}
+
+	private composeHeaders(
+		headers: Record<string, string> = {},
+		body?: unknown,
+	): Headers {
+		const composed = new Headers({
+			Authorization: `Bearer ${this.apiKey}`,
+			...this.defaultHeaders,
+			...headers,
+		});
+
+		if (
+			body !== undefined &&
+			!(body instanceof FormData) &&
+			!(body instanceof ArrayBuffer) &&
+			!(body instanceof Blob) &&
+			!(body instanceof URLSearchParams) &&
+			!composed.has("content-type")
+		) {
+			composed.set("content-type", JSON_CONTENT_TYPE);
+		}
+
+		return composed;
+	}
+
+	private serializeBody(
+		body: unknown,
+		contentType: string | null | undefined,
+	): BodyInit | undefined {
+		if (body === undefined || body === null) {
+			return undefined;
+		}
+
+		if (
+			body instanceof FormData ||
+			body instanceof Blob ||
+			body instanceof ArrayBuffer ||
+			body instanceof URLSearchParams ||
+			typeof body === "string"
+		) {
+			return body as BodyInit;
+		}
+
+		if (
+			contentType?.includes("application/x-www-form-urlencoded") &&
+			isPlainObject(body)
+		) {
+			const params = new URLSearchParams();
+			for (const [key, value] of Object.entries(body)) {
+				if (value === undefined || value === null) {
+					continue;
+				}
+				params.append(key, String(value));
+			}
+
+			return params;
+		}
+
+		if (contentType?.includes("application/json") || !contentType) {
+			return JSON.stringify(body);
+		}
+
+		return body as BodyInit;
+	}
+}
+
+async function safeReadResponse(response: Response): Promise<unknown> {
+	const contentType = response.headers.get("content-type");
+
+	if (!contentType) {
+		return undefined;
+	}
+
+	if (contentType.includes("application/json")) {
+		return response.json();
+	}
+
+	if (contentType.includes("text/")) {
+		return response.text();
+	}
+
+	return response.arrayBuffer();
+}
+
+export class OpenAIHttpError extends Error {
+	readonly status: number;
+	readonly statusText: string;
+	readonly body: unknown;
+	readonly headers: Headers;
+
+	constructor(
+		status: number,
+		statusText: string,
+		body: unknown,
+		headers: Headers = new Headers(),
+	) {
+		super(`OpenAI request failed with status ${status} ${statusText}`);
+		this.status = status;
+		this.statusText = statusText;
+		this.body = body;
+		this.headers = headers;
+	}
+}

--- a/app/api/open-ai/modules/module-factory.ts
+++ b/app/api/open-ai/modules/module-factory.ts
@@ -1,0 +1,53 @@
+import type {
+	OperationDefinition,
+	OperationRegistry,
+} from "./operation-registry";
+import type { OpenAIClient } from "../sdk/openai-client";
+
+export type OperationInvoker = (
+	options?: import("../sdk/openai-client").OperationCallOptions,
+) => Promise<unknown>;
+
+export type OperationModule = Record<string, OperationInvoker> & {
+	readonly tag: string;
+	readonly operations: readonly OperationDefinition[];
+};
+
+export function buildOperationModules(
+	registry: OperationRegistry,
+	client: OpenAIClient,
+): Record<string, OperationModule> {
+	const modules: Record<string, OperationModule> = {};
+
+	for (const [tag, operations] of registry.byTag.entries()) {
+		const invokers: Record<string, OperationInvoker> = {};
+
+		for (const operation of operations) {
+			invokers[operation.id] = (options) => client.call(operation.id, options);
+		}
+
+		const normalizedKey = normalizeTag(tag);
+
+		modules[normalizedKey] = Object.assign(invokers, {
+			operations,
+			tag,
+		});
+	}
+
+	return modules;
+}
+
+function normalizeTag(tag: string): string {
+	const sanitized = tag.trim();
+
+	if (sanitized.length === 0) {
+		return "untitled";
+	}
+
+	return sanitized
+		.toLowerCase()
+		.replace(/[^a-z0-9]+(.)?/g, (_, chr: string | undefined) =>
+			chr ? chr.toUpperCase() : "",
+		)
+		.replace(/^(\d)/, "_$1");
+}

--- a/app/api/open-ai/modules/operation-registry.ts
+++ b/app/api/open-ai/modules/operation-registry.ts
@@ -1,0 +1,183 @@
+import type {
+	OpenAPIOperation,
+	OpenAPIParameter,
+	OpenAPISpec,
+} from "./spec-loader";
+
+export type HttpMethod =
+	| "get"
+	| "put"
+	| "post"
+	| "delete"
+	| "options"
+	| "head"
+	| "patch"
+	| "trace";
+
+export interface OperationDefinition {
+	readonly id: string;
+	readonly method: HttpMethod;
+	readonly path: string;
+	readonly parameters: readonly OpenAPIParameter[];
+	readonly requestBody?: OpenAPIOperation["requestBody"];
+	readonly tags: readonly string[];
+}
+
+export interface OperationRegistry {
+	readonly byId: Map<string, OperationDefinition>;
+	readonly byTag: Map<string, readonly OperationDefinition[]>;
+	readonly matchers: readonly OperationMatcher[];
+}
+
+export interface MatchedOperation {
+	readonly operation: OperationDefinition;
+	readonly pathParams: Record<string, string>;
+}
+
+interface OperationMatcher {
+	readonly definition: OperationDefinition;
+	readonly segments: readonly PathSegment[];
+}
+
+type PathSegment =
+	| { readonly type: "literal"; readonly value: string }
+	| { readonly type: "parameter"; readonly name: string };
+
+export function buildOperationRegistry(spec: OpenAPISpec): OperationRegistry {
+	const byId = new Map<string, OperationDefinition>();
+	const byTag = new Map<string, OperationDefinition[]>();
+	const matchers: OperationMatcher[] = [];
+
+	for (const [path, operations] of Object.entries(spec.paths ?? {})) {
+		for (const [method, operation] of Object.entries(operations)) {
+			if (!isHttpMethod(method)) {
+				continue;
+			}
+
+			const operationId = operation.operationId;
+
+			if (!operationId) {
+				continue;
+			}
+
+			const parameters = operation.parameters ?? [];
+			const tags = operation.tags ?? ["uncategorized"];
+			const definition: OperationDefinition = {
+				id: operationId,
+				method,
+				path,
+				parameters,
+				requestBody: operation.requestBody,
+				tags,
+			};
+
+			byId.set(operationId, definition);
+			matchers.push(createMatcher(definition));
+
+			for (const tag of tags) {
+				const existing = byTag.get(tag) ?? [];
+				byTag.set(tag, [...existing, definition]);
+			}
+		}
+	}
+
+	return {
+		byId,
+		byTag: new Map(
+			[...byTag.entries()].map(([tag, items]) => [tag, [...items]]),
+		),
+		matchers,
+	};
+}
+
+export function isHttpMethod(value: string): value is HttpMethod {
+	return (
+		value === "get" ||
+		value === "put" ||
+		value === "post" ||
+		value === "delete" ||
+		value === "options" ||
+		value === "head" ||
+		value === "patch" ||
+		value === "trace"
+	);
+}
+
+export function matchOperationByPath(
+	registry: OperationRegistry,
+	method: HttpMethod,
+	path: string,
+): MatchedOperation | undefined {
+	const normalized = normalizePath(path);
+	const targetSegments = normalized === "" ? [] : normalized.split("/");
+
+	for (const matcher of registry.matchers) {
+		if (matcher.definition.method !== method) {
+			continue;
+		}
+
+		if (matcher.segments.length !== targetSegments.length) {
+			continue;
+		}
+
+		const pathParams: Record<string, string> = {};
+		let matched = true;
+
+		for (let index = 0; index < matcher.segments.length; index += 1) {
+			const segment = matcher.segments[index];
+			const candidate = targetSegments[index];
+
+			if (segment.type === "literal") {
+				if (segment.value !== candidate) {
+					matched = false;
+					break;
+				}
+
+				continue;
+			}
+
+			try {
+				pathParams[segment.name] = decodeURIComponent(candidate);
+			} catch {
+				pathParams[segment.name] = candidate;
+			}
+		}
+
+		if (matched) {
+			return { operation: matcher.definition, pathParams };
+		}
+	}
+
+	return undefined;
+}
+
+function createMatcher(definition: OperationDefinition): OperationMatcher {
+	const segments = splitPath(definition.path).map<PathSegment>((segment) => {
+		const parameterMatch = segment.match(/^\{(.+?)\}$/);
+
+		if (parameterMatch) {
+			return { type: "parameter", name: parameterMatch[1] };
+		}
+
+		return { type: "literal", value: segment };
+	});
+
+	return {
+		definition,
+		segments,
+	};
+}
+
+function splitPath(path: string): string[] {
+	const trimmed = normalizePath(path);
+
+	if (trimmed === "") {
+		return [];
+	}
+
+	return trimmed.split("/");
+}
+
+function normalizePath(path: string): string {
+	return path.replace(/^\/+/, "").replace(/\/+$/, "");
+}

--- a/app/api/open-ai/modules/spec-loader.ts
+++ b/app/api/open-ai/modules/spec-loader.ts
@@ -1,0 +1,56 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import YAML from "yaml";
+
+export interface OpenAPISpec {
+	readonly paths: Record<string, Record<string, OpenAPIOperation>>;
+}
+
+export interface OpenAPIOperation {
+	readonly operationId?: string;
+	readonly parameters?: readonly OpenAPIParameter[];
+	readonly requestBody?: OpenAPIRequestBody;
+	readonly tags?: readonly string[];
+}
+
+export interface OpenAPIParameter {
+	readonly name: string;
+	readonly in: "query" | "header" | "path" | "cookie";
+	readonly required?: boolean;
+}
+
+export interface OpenAPIRequestBody {
+	readonly required?: boolean;
+	readonly content?: Record<string, unknown>;
+}
+
+let cachedSpec: OpenAPISpec | null = null;
+
+export async function loadOpenAISpec(
+	specPath = path.join(
+		process.cwd(),
+		"app",
+		"api",
+		"open-ai",
+		"openapi.documented.yml",
+	),
+): Promise<OpenAPISpec> {
+	if (cachedSpec) {
+		return cachedSpec;
+	}
+
+	const file = await readFile(specPath, "utf8");
+	const parsed = YAML.parse(file) as OpenAPISpec;
+
+	if (!parsed?.paths) {
+		throw new Error("Invalid OpenAPI specification: missing paths definition");
+	}
+
+	cachedSpec = parsed;
+	return parsed;
+}
+
+export function resetOpenAISpecCache(): void {
+	cachedSpec = null;
+}

--- a/app/api/open-ai/modules/utils.ts
+++ b/app/api/open-ai/modules/utils.ts
@@ -1,0 +1,60 @@
+export function isPlainObject(
+	value: unknown,
+): value is Record<string, unknown> {
+	return (
+		value !== null &&
+		typeof value === "object" &&
+		(value as Record<string, unknown>).constructor === Object
+	);
+}
+
+export function applyPathParams(
+	path: string,
+	params: Record<string, unknown> = {},
+): string {
+	return path.replace(/\{(.*?)\}/g, (_, key: string) => {
+		if (!(key in params)) {
+			throw new Error(`Missing required path parameter: ${key}`);
+		}
+
+		return encodeURIComponent(String(params[key]));
+	});
+}
+
+export function extractQueryParams(
+	parameters: readonly { in: string; name: string }[],
+	provided: Record<string, unknown> = {},
+): Record<string, unknown> {
+	const result: Record<string, unknown> = {};
+
+	for (const parameter of parameters) {
+		if (parameter.in !== "query") {
+			continue;
+		}
+
+		if (parameter.name in provided) {
+			result[parameter.name] = provided[parameter.name];
+		}
+	}
+
+	return result;
+}
+
+export function extractHeaderParams(
+	parameters: readonly { in: string; name: string }[],
+	provided: Record<string, unknown> = {},
+): Record<string, string> {
+	const result: Record<string, string> = {};
+
+	for (const parameter of parameters) {
+		if (parameter.in !== "header") {
+			continue;
+		}
+
+		if (parameter.name in provided) {
+			result[parameter.name] = String(provided[parameter.name]);
+		}
+	}
+
+	return result;
+}

--- a/app/api/open-ai/route-support.ts
+++ b/app/api/open-ai/route-support.ts
@@ -1,0 +1,167 @@
+import type { HttpMethod } from "./modules/operation-registry";
+import type { OpenAPIParameter } from "./modules/spec-loader";
+import { OpenAIHttpError } from "./sdk/openai-client";
+
+const JSON_CONTENT_TYPE = "application/json; charset=utf-8";
+const HOP_BY_HOP_HEADERS = new Set([
+	"connection",
+	"keep-alive",
+	"proxy-authenticate",
+	"proxy-authorization",
+	"te",
+	"trailer",
+	"transfer-encoding",
+	"upgrade",
+]);
+
+export function buildQuery(
+	searchParams: URLSearchParams,
+): Record<string, unknown> {
+	const query: Record<string, unknown> = {};
+	const keys = new Set(searchParams.keys());
+
+	for (const key of keys) {
+		const values = searchParams.getAll(key);
+
+		if (values.length === 0) {
+			continue;
+		}
+
+		query[key] = values.length === 1 ? values[0] : values;
+	}
+
+	return query;
+}
+
+export function buildHeaderOverrides(
+	parameters: readonly OpenAPIParameter[],
+	incoming: Headers,
+): Record<string, string> {
+	const overrides: Record<string, string> = {};
+	const parameterNames = new Map<string, string>();
+
+	for (const parameter of parameters) {
+		if (parameter.in !== "header") {
+			continue;
+		}
+
+		parameterNames.set(parameter.name.toLowerCase(), parameter.name);
+	}
+
+	incoming.forEach((value, key) => {
+		if (!value) {
+			return;
+		}
+
+		const lowerKey = key.toLowerCase();
+
+		if (parameterNames.has(lowerKey)) {
+			overrides[parameterNames.get(lowerKey)!] = value;
+			return;
+		}
+
+		if (lowerKey.startsWith("openai-") || lowerKey.startsWith("x-oai-")) {
+			overrides[key] = value;
+		}
+	});
+
+	return overrides;
+}
+
+export async function readRequestBody(
+	method: HttpMethod,
+	request: Request,
+): Promise<unknown> {
+	if (method === "get" || method === "head") {
+		return undefined;
+	}
+
+	if (request.bodyUsed) {
+		return undefined;
+	}
+
+	const contentType = request.headers.get("content-type");
+
+	if (!contentType) {
+		return request.arrayBuffer();
+	}
+
+	if (contentType.includes("application/json")) {
+		return request.json();
+	}
+
+	if (contentType.includes("multipart/form-data")) {
+		return request.formData();
+	}
+
+	if (contentType.includes("application/x-www-form-urlencoded")) {
+		const text = await request.text();
+		return Object.fromEntries(new URLSearchParams(text));
+	}
+
+	if (contentType.startsWith("text/")) {
+		return request.text();
+	}
+
+	return request.arrayBuffer();
+}
+
+export function forwardResponse(upstream: Response): Response {
+	const headers = new Headers();
+
+	upstream.headers.forEach((value, key) => {
+		if (HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+			return;
+		}
+
+		headers.set(key, value);
+	});
+
+	return new Response(upstream.body, {
+		status: upstream.status,
+		statusText: upstream.statusText,
+		headers,
+	});
+}
+
+export function buildErrorResponse(error: OpenAIHttpError): Response {
+	const headers = new Headers();
+	error.headers.forEach((value, key) => {
+		if (HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+			return;
+		}
+
+		headers.set(key, value);
+	});
+
+	let body: BodyInit | null = null;
+
+	if (error.body === undefined || error.body === null) {
+		body = null;
+	} else if (typeof error.body === "string") {
+		body = error.body;
+		if (!headers.has("content-type")) {
+			headers.set("content-type", "text/plain; charset=utf-8");
+		}
+	} else if (error.body instanceof ArrayBuffer) {
+		body = error.body;
+	} else {
+		body = JSON.stringify(error.body);
+		if (!headers.has("content-type")) {
+			headers.set("content-type", JSON_CONTENT_TYPE);
+		}
+	}
+
+	return new Response(body, {
+		status: error.status,
+		statusText: error.statusText,
+		headers,
+	});
+}
+
+export function jsonErrorResponse(status: number, message: string): Response {
+	return new Response(JSON.stringify({ error: message }), {
+		status,
+		headers: { "content-type": JSON_CONTENT_TYPE },
+	});
+}

--- a/app/api/open-ai/sdk/index.ts
+++ b/app/api/open-ai/sdk/index.ts
@@ -1,0 +1,6 @@
+export {
+	OpenAIClient,
+	type OpenAIClientConfig,
+	type OperationCallOptions,
+	OpenAIHttpError,
+} from "./openai-client";

--- a/app/api/open-ai/sdk/openai-client.ts
+++ b/app/api/open-ai/sdk/openai-client.ts
@@ -1,0 +1,193 @@
+import { buildOperationModules } from "../modules/module-factory";
+import {
+	HttpClient,
+	type RequestOptions,
+	OpenAIHttpError,
+} from "../modules/http-client";
+import {
+	buildOperationRegistry,
+	type OperationDefinition,
+	type OperationRegistry,
+	matchOperationByPath,
+	type MatchedOperation,
+	type HttpMethod,
+} from "../modules/operation-registry";
+import {
+	applyPathParams,
+	extractHeaderParams,
+	extractQueryParams,
+} from "../modules/utils";
+import { loadOpenAISpec } from "../modules/spec-loader";
+
+export interface OpenAIClientConfig {
+	readonly apiKey: string;
+	readonly baseUrl?: string;
+	readonly defaultHeaders?: Record<string, string>;
+	readonly specPath?: string;
+	readonly requestDefaults?: {
+		readonly headers?: Record<string, string>;
+		readonly query?: Record<string, unknown>;
+	};
+}
+
+export interface OperationCallOptions {
+	readonly pathParams?: Record<string, unknown>;
+	readonly query?: Record<string, unknown>;
+	readonly headers?: Record<string, unknown>;
+	readonly body?: unknown;
+	readonly signal?: AbortSignal;
+}
+
+export class OpenAIClient {
+	private readonly httpClient: HttpClient;
+	private readonly registryPromise: Promise<OperationRegistry>;
+	private modulesCache: Record<
+		string,
+		import("../modules/module-factory").OperationModule
+	> | null = null;
+	private readonly requestDefaults: Required<
+		OpenAIClientConfig["requestDefaults"]
+	>;
+
+	constructor(config: OpenAIClientConfig) {
+		if (!config.apiKey) {
+			throw new Error("OpenAIClient requires an apiKey");
+		}
+
+		this.httpClient = new HttpClient({
+			apiKey: config.apiKey,
+			baseUrl: config.baseUrl ?? "https://api.openai.com/v1",
+			defaultHeaders: config.defaultHeaders,
+		});
+		this.registryPromise = this.loadRegistry(config.specPath);
+		this.requestDefaults = {
+			headers: config.requestDefaults?.headers ?? {},
+			query: config.requestDefaults?.query ?? {},
+		};
+	}
+
+	async call<T = unknown>(
+		operationId: string,
+		options: OperationCallOptions = {},
+	): Promise<T> {
+		const response = await this.callRaw(operationId, options);
+		return this.httpClient.parseResponse<T>(response);
+	}
+
+	async callRaw(
+		operationId: string,
+		options: OperationCallOptions = {},
+	): Promise<Response> {
+		const operation = await this.getOperationOrThrow(operationId);
+		const requestOptions = this.composeRequestOptions(operation, options);
+		return this.httpClient.requestRaw(requestOptions);
+	}
+
+	async getOperation(
+		operationId: string,
+	): Promise<OperationDefinition | undefined> {
+		const registry = await this.registryPromise;
+		return registry.byId.get(operationId);
+	}
+
+	async resolveOperation(
+		method: HttpMethod,
+		path: string,
+	): Promise<MatchedOperation | undefined> {
+		const registry = await this.registryPromise;
+		return matchOperationByPath(registry, method, path);
+	}
+
+	async modules(): Promise<
+		Record<string, import("../modules/module-factory").OperationModule>
+	> {
+		if (this.modulesCache) {
+			return this.modulesCache;
+		}
+
+		const registry = await this.registryPromise;
+		this.modulesCache = buildOperationModules(registry, this);
+		return this.modulesCache;
+	}
+
+	private async loadRegistry(specPath?: string): Promise<OperationRegistry> {
+		const spec = await loadOpenAISpec(specPath);
+		return buildOperationRegistry(spec);
+	}
+
+	private async getOperationOrThrow(
+		operationId: string,
+	): Promise<OperationDefinition> {
+		const registry = await this.registryPromise;
+		const operation = registry.byId.get(operationId);
+
+		if (!operation) {
+			throw new Error(`Unknown OpenAI operation: ${operationId}`);
+		}
+
+		return operation;
+	}
+
+	private composeRequestOptions(
+		operation: OperationDefinition,
+		options: OperationCallOptions,
+	): RequestOptions {
+		const path = applyPathParams(operation.path, options.pathParams ?? {});
+
+		const query: Record<string, unknown> = {};
+		mergeDefined(query, this.requestDefaults.query);
+		mergeDefined(
+			query,
+			extractQueryParams(operation.parameters, options.query ?? {}),
+		);
+		mergeDefined(query, options.query ?? {});
+
+		const headers: Record<string, string> = {};
+		mergeDefined(headers, this.requestDefaults.headers);
+		mergeDefined(
+			headers,
+			extractHeaderParams(operation.parameters, options.headers ?? {}),
+		);
+		mergeDefined(headers, stringifyHeaderValues(options.headers ?? {}));
+
+		return {
+			method: operation.method,
+			path,
+			query,
+			headers,
+			body: options.body,
+			signal: options.signal,
+		} satisfies RequestOptions;
+	}
+}
+
+export { OpenAIHttpError };
+
+function mergeDefined<T extends Record<string, unknown>>(
+	target: Record<string, unknown>,
+	source: T,
+): void {
+	for (const [key, value] of Object.entries(source)) {
+		if (value === undefined) {
+			continue;
+		}
+
+		target[key] = value;
+	}
+}
+
+function stringifyHeaderValues(
+	headers: Record<string, unknown>,
+): Record<string, string> {
+	const result: Record<string, string> = {};
+
+	for (const [key, value] of Object.entries(headers)) {
+		if (value === undefined || value === null) {
+			continue;
+		}
+
+		result[key] = String(value);
+	}
+
+	return result;
+}

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
 		"use-stick-to-bottom": "^1.1.1",
 		"xai": "^0.1.0",
 		"zod": "^4.0.17",
-		"zustand": "^5.0.7"
+		"zustand": "^5.0.7",
+		"yaml": "^2.6.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       xai:
         specifier: ^0.1.0
         version: 0.1.0
+      yaml:
+        specifier: ^2.6.0
+        version: 2.6.1
       zod:
         specifier: ^4.0.17
         version: 4.0.17


### PR DESCRIPTION
## Summary
- add a catch-all OpenAI API route that resolves documented operations and proxies requests through the modular client
- factor shared request parsing and response helpers into a reusable route-support module
- extend the registry and SDK to match operations by path/method and expose raw-call support for streaming responses

## Testing
- pnpm test -- app/api/open-ai/modules/__tests__/registry.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5c3c972388329b50730ae2731726e