### PR TITLE
feat: align DeepSeek schemas with documented features

### DIFF
--- a/app/api/deep-seek/client.ts
+++ b/app/api/deep-seek/client.ts
@@ -1,0 +1,22 @@
+import { DeepSeekClient } from "./sdk";
+
+let cachedClient: DeepSeekClient | null = null;
+
+export function getDeepSeekClient(): DeepSeekClient {
+	if (cachedClient) {
+		return cachedClient;
+	}
+
+	const apiKey = process.env.DEEPSEEK_API_KEY;
+
+	if (!apiKey) {
+		throw new Error("DEEPSEEK_API_KEY is not configured");
+	}
+
+	cachedClient = new DeepSeekClient({
+		apiKey,
+		baseUrl: process.env.DEEPSEEK_API_BASE ?? "https://api.deepseek.com/v1",
+	});
+
+	return cachedClient;
+}

--- a/app/api/deep-seek/modules/http-client.ts
+++ b/app/api/deep-seek/modules/http-client.ts
@@ -1,0 +1,202 @@
+import { URLSearchParams } from "node:url";
+
+import type { HttpMethod } from "./operation-registry";
+import { isPlainObject } from "./utils";
+
+const JSON_CONTENT_TYPE = "application/json";
+
+export interface HttpClientConfig {
+	readonly baseUrl: string;
+	readonly apiKey: string;
+	readonly defaultHeaders?: Record<string, string>;
+}
+
+export interface RequestOptions {
+	readonly method: HttpMethod;
+	readonly path: string;
+	readonly query?: Record<string, unknown>;
+	readonly headers?: Record<string, string>;
+	readonly body?: unknown;
+	readonly signal?: AbortSignal;
+}
+
+export class HttpClient {
+	private readonly baseUrl: string;
+	private readonly apiKey: string;
+	private readonly defaultHeaders: Record<string, string>;
+
+	constructor(config: HttpClientConfig) {
+		this.baseUrl = config.baseUrl;
+		this.apiKey = config.apiKey;
+		this.defaultHeaders = config.defaultHeaders ?? {};
+	}
+
+	async request<T = unknown>(options: RequestOptions): Promise<T> {
+		const response = await this.requestRaw(options);
+		return this.parseResponse<T>(response);
+	}
+
+	async requestRaw({
+		method,
+		path,
+		query,
+		headers,
+		body,
+		signal,
+	}: RequestOptions): Promise<Response> {
+		const url = this.composeUrl(path, query);
+		const composedHeaders = this.composeHeaders(headers, body);
+		const response = await fetch(url, {
+			method: method.toUpperCase(),
+			headers: composedHeaders,
+			body: this.serializeBody(body, composedHeaders.get("content-type")),
+			signal,
+		});
+
+		if (!response.ok) {
+			const errorBody = await safeReadResponse(response.clone());
+			throw new DeepSeekHttpError(
+				response.status,
+				response.statusText,
+				errorBody,
+				new Headers(response.headers),
+			);
+		}
+
+		return response;
+	}
+
+	async parseResponse<T = unknown>(response: Response): Promise<T> {
+		return (await safeReadResponse(response)) as T;
+	}
+
+	private composeUrl(path: string, query?: Record<string, unknown>): string {
+		const url = new URL(
+			path,
+			this.baseUrl.endsWith("/") ? this.baseUrl : `${this.baseUrl}/`,
+		);
+
+		if (query && Object.keys(query).length > 0) {
+			const params = new URLSearchParams();
+			for (const [key, value] of Object.entries(query)) {
+				if (value === undefined || value === null) {
+					continue;
+				}
+
+				if (Array.isArray(value)) {
+					for (const item of value) {
+						params.append(key, String(item));
+					}
+				} else {
+					params.append(key, String(value));
+				}
+			}
+
+			url.search = params.toString();
+		}
+
+		return url.toString();
+	}
+
+	private composeHeaders(
+		headers: Record<string, string> = {},
+		body?: unknown,
+	): Headers {
+		const composed = new Headers({
+			Authorization: `Bearer ${this.apiKey}`,
+			...this.defaultHeaders,
+			...headers,
+		});
+
+		if (
+			body !== undefined &&
+			!(body instanceof FormData) &&
+			!(body instanceof ArrayBuffer) &&
+			!(body instanceof Blob) &&
+			!(body instanceof URLSearchParams) &&
+			!composed.has("content-type")
+		) {
+			composed.set("content-type", JSON_CONTENT_TYPE);
+		}
+
+		return composed;
+	}
+
+	private serializeBody(
+		body: unknown,
+		contentType: string | null | undefined,
+	): BodyInit | undefined {
+		if (body === undefined || body === null) {
+			return undefined;
+		}
+
+		if (
+			body instanceof FormData ||
+			body instanceof Blob ||
+			body instanceof ArrayBuffer ||
+			body instanceof URLSearchParams ||
+			typeof body === "string"
+		) {
+			return body as BodyInit;
+		}
+
+		if (
+			contentType?.includes("application/x-www-form-urlencoded") &&
+			isPlainObject(body)
+		) {
+			const params = new URLSearchParams();
+			for (const [key, value] of Object.entries(body)) {
+				if (value === undefined || value === null) {
+					continue;
+				}
+				params.append(key, String(value));
+			}
+
+			return params;
+		}
+
+		if (contentType?.includes("application/json") || !contentType) {
+			return JSON.stringify(body);
+		}
+
+		return body as BodyInit;
+	}
+}
+
+async function safeReadResponse(response: Response): Promise<unknown> {
+	const contentType = response.headers.get("content-type");
+
+	if (!contentType) {
+		return undefined;
+	}
+
+	if (contentType.includes("application/json")) {
+		return response.json();
+	}
+
+	if (contentType.includes("text/")) {
+		return response.text();
+	}
+
+	return response.arrayBuffer();
+}
+
+export class DeepSeekHttpError extends Error {
+	readonly status: number;
+	readonly statusText: string;
+	readonly body: unknown;
+	readonly headers: Headers;
+
+	constructor(
+		status: number,
+		statusText: string,
+		body: unknown,
+		headers: Headers = new Headers(),
+	) {
+		super(`DeepSeek request failed with status ${status} ${statusText}`);
+		this.status = status;
+		this.statusText = statusText;
+		this.body = body;
+		this.headers = headers;
+	}
+}

--- a/app/api/deep-seek/modules/module-factory.ts
+++ b/app/api/deep-seek/modules/module-factory.ts
@@ -1,0 +1,59 @@
+import type {
+	OperationDefinition,
+	OperationRegistry,
+} from "./operation-registry";
+import type { DeepSeekClient } from "../sdk/deepseek-client";
+
+export type OperationInvoker = (
+	options?: import("../sdk/deepseek-client").OperationCallOptions,
+) => Promise<unknown>;
+
+export type OperationModule = Record<string, OperationInvoker> & {
+	readonly tag: string;
+	readonly operations: readonly OperationDefinition[];
+};
+
+export function buildOperationModules(
+	registry: OperationRegistry,
+	client: DeepSeekClient,
+): Record<string, OperationModule> {
+	const modules: Record<string, OperationModule> = {};
+
+	for (const [tag, operations] of registry.byTag.entries()) {
+		const invokers: Record<string, OperationInvoker> = {};
+
+		for (const operation of operations) {
+			invokers[operation.id] = (options) => client.call(operation.id, options);
+		}
+
+		const normalizedKey = normalizeTag(tag);
+
+		modules[normalizedKey] = Object.assign(invokers, {
+			operations,
+			tag,
+		});
+	}
+
+	return modules;
+}
+
+function normalizeTag(tag: string): string {
+	const sanitized = tag.trim().toLowerCase();
+
+	if (sanitized.length === 0) {
+		return "untitled";
+	}
+
+	const firstToken = sanitized.split(/\s+/)[0] ?? sanitized;
+	const cleaned = firstToken.replace(/[^a-z0-9]/g, "");
+
+	if (cleaned.length === 0) {
+		return "untitled";
+	}
+
+	if (/^\d/.test(cleaned)) {
+		return `_${cleaned}`;
+	}
+
+	return cleaned;
+}

--- a/app/api/deep-seek/modules/operation-registry.ts
+++ b/app/api/deep-seek/modules/operation-registry.ts
@@ -1,0 +1,145 @@
+export type HttpMethod =
+	| "get"
+	| "put"
+	| "post"
+	| "delete"
+	| "options"
+	| "head"
+	| "patch"
+	| "trace";
+
+export interface OperationParameter {
+	readonly in: "path" | "query" | "header";
+	readonly name: string;
+	readonly required?: boolean;
+}
+
+export interface OperationDefinition {
+	readonly id: string;
+	readonly method: HttpMethod;
+	readonly path: string;
+	readonly tag: string;
+	readonly summary: string;
+	readonly parameters: readonly OperationParameter[];
+}
+
+export interface OperationRegistry {
+	readonly byId: Map<string, OperationDefinition>;
+	readonly byTag: Map<string, readonly OperationDefinition[]>;
+	readonly matchers: readonly OperationMatcher[];
+}
+
+export interface MatchedOperation {
+	readonly operation: OperationDefinition;
+	readonly pathParams: Record<string, string>;
+}
+
+interface OperationMatcher {
+	readonly definition: OperationDefinition;
+	readonly segments: readonly PathSegment[];
+}
+
+type PathSegment =
+	| { readonly type: "literal"; readonly value: string }
+	| { readonly type: "parameter"; readonly name: string };
+
+export function buildOperationRegistry(
+	operations: readonly OperationDefinition[],
+): OperationRegistry {
+	const byId = new Map<string, OperationDefinition>();
+	const byTag = new Map<string, OperationDefinition[]>();
+	const matchers: OperationMatcher[] = [];
+
+	for (const operation of operations) {
+		byId.set(operation.id, operation);
+		matchers.push(createMatcher(operation));
+
+		const existing = byTag.get(operation.tag) ?? [];
+		byTag.set(operation.tag, [...existing, operation]);
+	}
+
+	return {
+		byId,
+		byTag: new Map([...byTag.entries()].map(([tag, defs]) => [tag, [...defs]])),
+		matchers,
+	};
+}
+
+export function matchOperationByPath(
+	registry: OperationRegistry,
+	method: HttpMethod,
+	path: string,
+): MatchedOperation | undefined {
+	const normalized = normalizePath(path);
+	const targetSegments = normalized === "" ? [] : normalized.split("/");
+
+	for (const matcher of registry.matchers) {
+		if (matcher.definition.method !== method) {
+			continue;
+		}
+
+		if (matcher.segments.length !== targetSegments.length) {
+			continue;
+		}
+
+		const pathParams: Record<string, string> = {};
+		let matched = true;
+
+		for (let index = 0; index < matcher.segments.length; index += 1) {
+			const segment = matcher.segments[index];
+			const candidate = targetSegments[index];
+
+			if (segment.type === "literal") {
+				if (segment.value !== candidate) {
+					matched = false;
+					break;
+				}
+
+				continue;
+			}
+
+			try {
+				pathParams[segment.name] = decodeURIComponent(candidate);
+			} catch {
+				pathParams[segment.name] = candidate;
+			}
+		}
+
+		if (matched) {
+			return { operation: matcher.definition, pathParams };
+		}
+	}
+
+	return undefined;
+}
+
+function createMatcher(definition: OperationDefinition): OperationMatcher {
+	const segments = splitPath(definition.path).map<PathSegment>((segment) => {
+		const parameterMatch = segment.match(/^\{(.+?)\}$/);
+
+		if (parameterMatch) {
+			return { type: "parameter", name: parameterMatch[1] };
+		}
+
+		return { type: "literal", value: segment };
+	});
+
+	return {
+		definition,
+		segments,
+	};
+}
+
+function splitPath(path: string): string[] {
+	const trimmed = normalizePath(path);
+
+	if (trimmed === "") {
+		return [];
+	}
+
+	return trimmed.split("/");
+}
+
+function normalizePath(path: string): string {
+	return path.replace(/^\/+/, "").replace(/\/+$/, "");
+}

--- a/app/api/deep-seek/modules/operations.ts
+++ b/app/api/deep-seek/modules/operations.ts
@@ -1,0 +1,83 @@
+import type { OperationDefinition } from "./operation-registry";
+
+export const DEFAULT_OPERATIONS: readonly OperationDefinition[] = [
+	{
+		id: "listModels",
+		method: "get",
+		path: "models",
+		tag: "Models",
+		summary: "List available DeepSeek models.",
+		parameters: [],
+	},
+	{
+		id: "retrieveModel",
+		method: "get",
+		path: "models/{model}",
+		tag: "Models",
+		summary: "Retrieve metadata for a specific model.",
+		parameters: [{ in: "path", name: "model", required: true }],
+	},
+	{
+		id: "getUserBalance",
+		method: "get",
+		path: "user/balance",
+		tag: "Billing",
+		summary: "Fetch the current DeepSeek account balance information.",
+		parameters: [],
+	},
+	{
+		id: "createChatCompletion",
+		method: "post",
+		path: "chat/completions",
+		tag: "Chat Completions",
+		summary: "Create a chat completion using DeepSeek chat models.",
+		parameters: [
+			{ in: "query", name: "stream" },
+			{ in: "query", name: "safe" },
+			{ in: "query", name: "temperature" },
+		],
+	},
+	{
+		id: "createReasoningCompletion",
+		method: "post",
+		path: "reasoning/completions",
+		tag: "Reasoning",
+		summary: "Invoke DeepSeek reasoning models for extended outputs.",
+		parameters: [
+			{ in: "query", name: "stream" },
+			{ in: "query", name: "temperature" },
+		],
+	},
+	{
+		id: "createEmbedding",
+		method: "post",
+		path: "embeddings",
+		tag: "Embeddings",
+		summary: "Generate embedding vectors using DeepSeek embedding models.",
+		parameters: [],
+	},
+	{
+		id: "createSpeech",
+		method: "post",
+		path: "audio/speech",
+		tag: "Audio",
+		summary: "Synthesize speech from text using DeepSeek TTS models.",
+		parameters: [{ in: "header", name: "accept" }],
+	},
+	{
+		id: "createFimCompletion",
+		method: "post",
+		path: "beta/completions",
+		tag: "Beta",
+		summary: "Call the beta Fill-in-the-Middle completion endpoint.",
+		parameters: [],
+	},
+	{
+		id: "createAnthropicMessage",
+		method: "post",
+		path: "anthropic/messages",
+		tag: "Anthropic Compatibility",
+		summary: "Invoke DeepSeek via the Anthropic-compatible API surface.",
+		parameters: [],
+	},
+];

--- a/app/api/deep-seek/modules/utils.ts
+++ b/app/api/deep-seek/modules/utils.ts
@@ -1,0 +1,60 @@
+export function isPlainObject(
+	value: unknown,
+): value is Record<string, unknown> {
+	return (
+		value !== null &&
+		typeof value === "object" &&
+		(value as Record<string, unknown>).constructor === Object
+	);
+}
+
+export function applyPathParams(
+	path: string,
+	params: Record<string, unknown> = {},
+): string {
+	return path.replace(/\{(.*?)\}/g, (_, key: string) => {
+		if (!(key in params)) {
+			throw new Error(`Missing required path parameter: ${key}`);
+		}
+
+		return encodeURIComponent(String(params[key]));
+	});
+}
+
+export function extractQueryParams(
+	parameters: readonly { in: string; name: string }[],
+	provided: Record<string, unknown> = {},
+): Record<string, unknown> {
+	const result: Record<string, unknown> = {};
+
+	for (const parameter of parameters) {
+		if (parameter.in !== "query") {
+			continue;
+		}
+
+		if (parameter.name in provided) {
+			result[parameter.name] = provided[parameter.name];
+		}
+	}
+
+	return result;
+}
+
+export function extractHeaderParams(
+	parameters: readonly { in: string; name: string }[],
+	provided: Record<string, unknown> = {},
+): Record<string, string> {
+	const result: Record<string, string> = {};
+
+	for (const parameter of parameters) {
+		if (parameter.in !== "header") {
+			continue;
+		}
+
+		if (parameter.name in provided) {
+			result[parameter.name] = String(provided[parameter.name]);
+		}
+	}
+
+	return result;
+}

--- a/app/api/deep-seek/sdk/deepseek-client.ts
+++ b/app/api/deep-seek/sdk/deepseek-client.ts
@@ -1,0 +1,190 @@
+import { buildOperationModules } from "../modules/module-factory";
+import {
+	buildOperationRegistry,
+	matchOperationByPath,
+	type HttpMethod,
+	type MatchedOperation,
+	type OperationDefinition,
+	type OperationRegistry,
+} from "../modules/operation-registry";
+import { DEFAULT_OPERATIONS } from "../modules/operations";
+import {
+	applyPathParams,
+	extractHeaderParams,
+	extractQueryParams,
+} from "../modules/utils";
+import {
+	HttpClient,
+	type RequestOptions,
+	DeepSeekHttpError,
+} from "../modules/http-client";
+
+export interface DeepSeekClientConfig {
+	readonly apiKey: string;
+	readonly baseUrl?: string;
+	readonly defaultHeaders?: Record<string, string>;
+	readonly operations?: readonly OperationDefinition[];
+	readonly requestDefaults?: {
+		readonly headers?: Record<string, string>;
+		readonly query?: Record<string, unknown>;
+	};
+}
+
+export interface OperationCallOptions {
+	readonly pathParams?: Record<string, unknown>;
+	readonly query?: Record<string, unknown>;
+	readonly headers?: Record<string, unknown>;
+	readonly body?: unknown;
+	readonly signal?: AbortSignal;
+}
+
+export class DeepSeekClient {
+	private readonly httpClient: HttpClient;
+	private readonly registryPromise: Promise<OperationRegistry>;
+	private modulesCache: Record<
+		string,
+		import("../modules/module-factory").OperationModule
+	> | null = null;
+	private readonly requestDefaults: Required<
+		NonNullable<DeepSeekClientConfig["requestDefaults"]>
+	>;
+
+	constructor(config: DeepSeekClientConfig) {
+		if (!config.apiKey) {
+			throw new Error("DeepSeekClient requires an apiKey");
+		}
+
+		this.httpClient = new HttpClient({
+			apiKey: config.apiKey,
+			baseUrl: config.baseUrl ?? "https://api.deepseek.com/v1",
+			defaultHeaders: config.defaultHeaders,
+		});
+
+		const operations = config.operations ?? DEFAULT_OPERATIONS;
+		this.registryPromise = Promise.resolve(buildOperationRegistry(operations));
+		this.requestDefaults = {
+			headers: config.requestDefaults?.headers ?? {},
+			query: config.requestDefaults?.query ?? {},
+		};
+	}
+
+	async call<T = unknown>(
+		operationId: string,
+		options: OperationCallOptions = {},
+	): Promise<T> {
+		const response = await this.callRaw(operationId, options);
+		return this.httpClient.parseResponse<T>(response);
+	}
+
+	async callRaw(
+		operationId: string,
+		options: OperationCallOptions = {},
+	): Promise<Response> {
+		const operation = await this.getOperationOrThrow(operationId);
+		const requestOptions = this.composeRequestOptions(operation, options);
+		return this.httpClient.requestRaw(requestOptions);
+	}
+
+	async getOperation(
+		operationId: string,
+	): Promise<OperationDefinition | undefined> {
+		const registry = await this.registryPromise;
+		return registry.byId.get(operationId);
+	}
+
+	async resolveOperation(
+		method: HttpMethod,
+		path: string,
+	): Promise<MatchedOperation | undefined> {
+		const registry = await this.registryPromise;
+		return matchOperationByPath(registry, method, path);
+	}
+
+	async modules(): Promise<
+		Record<string, import("../modules/module-factory").OperationModule>
+	> {
+		if (this.modulesCache) {
+			return this.modulesCache;
+		}
+
+		const registry = await this.registryPromise;
+		this.modulesCache = buildOperationModules(registry, this);
+		return this.modulesCache;
+	}
+
+	private async getOperationOrThrow(
+		operationId: string,
+	): Promise<OperationDefinition> {
+		const registry = await this.registryPromise;
+		const operation = registry.byId.get(operationId);
+
+		if (!operation) {
+			throw new Error(`Unknown DeepSeek operation: ${operationId}`);
+		}
+
+		return operation;
+	}
+
+	private composeRequestOptions(
+		operation: OperationDefinition,
+		options: OperationCallOptions,
+	): RequestOptions {
+		const path = applyPathParams(operation.path, options.pathParams ?? {});
+
+		const query: Record<string, unknown> = {};
+		mergeDefined(query, this.requestDefaults.query);
+		mergeDefined(
+			query,
+			extractQueryParams(operation.parameters, options.query ?? {}),
+		);
+		mergeDefined(query, options.query ?? {});
+
+		const headers: Record<string, string> = {};
+		mergeDefined(headers, this.requestDefaults.headers);
+		mergeDefined(
+			headers,
+			extractHeaderParams(operation.parameters, options.headers ?? {}),
+		);
+		mergeDefined(headers, stringifyHeaderValues(options.headers ?? {}));
+
+		return {
+			method: operation.method,
+			path,
+			query,
+			headers,
+			body: options.body,
+			signal: options.signal,
+		} satisfies RequestOptions;
+	}
+}
+
+export { DeepSeekHttpError };
+
+function mergeDefined<T extends Record<string, unknown>>(
+	target: Record<string, unknown>,
+	source: T,
+): void {
+	for (const [key, value] of Object.entries(source)) {
+		if (value === undefined) {
+			continue;
+		}
+
+		target[key] = value;
+	}
+}
+
+function stringifyHeaderValues(
+	headers: Record<string, unknown>,
+): Record<string, string> {
+	const result: Record<string, string> = {};
+
+	for (const [key, value] of Object.entries(headers)) {
+		if (value === undefined || value === null) {
+			continue;
+		}
+
+		result[key] = String(value);
+	}
+
+	return result;
+}

--- a/app/api/deep-seek/sdk/index.ts
+++ b/app/api/deep-seek/sdk/index.ts
@@ -1,0 +1,6 @@
+export {
+	DeepSeekClient,
+	type DeepSeekClientConfig,
+	type OperationCallOptions,
+	DeepSeekHttpError,
+} from "./deepseek-client";

--- a/app/api/deep-seek/tests/deepseek-client.test.ts
+++ b/app/api/deep-seek/tests/deepseek-client.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DeepSeekClient } from "../sdk/deepseek-client";
+
+const CREATE_CHAT_COMPLETION = "createChatCompletion";
+
+async function createMockResponse(
+	body: unknown,
+	init?: ResponseInit,
+): Promise<Response> {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+		...init,
+	});
+}
+
+describe("DeepSeek modular SDK", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("requires an API key", () => {
+		expect(() => new DeepSeekClient({ apiKey: "" })).toThrow(
+			/DeepSeekClient requires an apiKey/,
+		);
+	});
+
+	it("exposes grouped operation modules", async () => {
+		const client = new DeepSeekClient({ apiKey: "test" });
+		const modules = await client.modules();
+
+		expect(modules.chat).toBeDefined();
+		expect(modules.chat.tag).toBe("Chat Completions");
+		expect(typeof modules.chat[CREATE_CHAT_COMPLETION]).toBe("function");
+
+		expect(modules.models).toBeDefined();
+		expect(modules.models.operations.some((op) => op.id === "listModels")).toBe(
+			true,
+		);
+
+		expect(modules.billing).toBeDefined();
+		expect(
+			modules.billing.operations.some((op) => op.id === "getUserBalance"),
+		).toBe(true);
+
+		expect(modules.beta).toBeDefined();
+		expect(
+			modules.beta.operations.some((op) => op.id === "createFimCompletion"),
+		).toBe(true);
+	});
+
+	it("throws when invoking unknown operations", async () => {
+		const client = new DeepSeekClient({ apiKey: "test" });
+
+		await expect(client.call("doesNotExist" as never)).rejects.toThrow(
+			/Unknown DeepSeek operation/,
+		);
+	});
+
+	it("matches operations by HTTP method and path", async () => {
+		const client = new DeepSeekClient({ apiKey: "test" });
+		const match = await client.resolveOperation("get", "/models/deepseek-chat");
+
+		expect(match?.operation.id).toBe("retrieveModel");
+		expect(match?.pathParams).toEqual({ model: "deepseek-chat" });
+	});
+
+	it("resolves beta and anthropic compatibility routes", async () => {
+		const client = new DeepSeekClient({ apiKey: "test" });
+
+		const betaMatch = await client.resolveOperation(
+			"post",
+			"/beta/completions",
+		);
+
+		expect(betaMatch?.operation.id).toBe("createFimCompletion");
+
+		const anthropicMatch = await client.resolveOperation(
+			"post",
+			"/anthropic/messages",
+		);
+
+		expect(anthropicMatch?.operation.id).toBe("createAnthropicMessage");
+	});
+
+	it("performs HTTP requests with merged defaults", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockImplementation((input: RequestInfo | URL, init?: RequestInit) =>
+				createMockResponse({ id: "resp_123", input, init }),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const client = new DeepSeekClient({
+			apiKey: "sk-test",
+			baseUrl: "https://gateway.deepseek.example/v1",
+			requestDefaults: {
+				headers: { "x-default": "alpha" },
+				query: { safe: true },
+			},
+		});
+
+		const result = await client.call<{ id: string }>(CREATE_CHAT_COMPLETION, {
+			body: { model: "deepseek-chat", messages: [] },
+			headers: { "x-request": "beta" },
+			query: { safe: false, temperature: 0.6 },
+		});
+
+		expect(result.id).toBe("resp_123");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(String(url)).toBe(
+			"https://gateway.deepseek.example/v1/chat/completions?safe=false&temperature=0.6",
+		);
+		expect(init?.method).toBe("POST");
+
+		const headers = new Headers(init?.headers);
+		expect(headers.get("authorization")).toBe("Bearer sk-test");
+		expect(headers.get("x-default")).toBe("alpha");
+		expect(headers.get("x-request")).toBe("beta");
+
+		const parsedBody = JSON.parse(String(init?.body));
+		expect(parsedBody.model).toBe("deepseek-chat");
+	});
+});

--- a/app/api/deep-seek/tests/zod-schemas.test.ts
+++ b/app/api/deep-seek/tests/zod-schemas.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	BalanceResponseSchema,
+	ChatCompletionRequestSchema,
+	ChatCompletionResponseSchema,
+	EmbeddingRequestSchema,
+	EmbeddingResponseSchema,
+	ListModelsResponseSchema,
+	SpeechSynthesisRequestSchema,
+} from "../zod-schemas";
+
+describe("DeepSeek Zod schemas", () => {
+	it("validates chat completion payloads", () => {
+		const requestResult = ChatCompletionRequestSchema.safeParse({
+			model: "deepseek-chat",
+			messages: [
+				{ role: "user", content: "Hello" },
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "```python\n" }],
+					prefix: true,
+				},
+				{
+					role: "tool",
+					tool_call_id: "call_123",
+					content: '{"temperature":24}',
+				},
+			],
+			temperature: 0.3,
+			stream: false,
+			stream_options: { include_usage: true },
+			tools: [
+				{
+					type: "function",
+					function: {
+						name: "get_weather",
+						description: "Retrieve the weather for a given location",
+						strict: true,
+						parameters: {
+							type: "object",
+							properties: {
+								location: {
+									type: "string",
+									description: "City name",
+								},
+							},
+							required: ["location"],
+							additionalProperties: false,
+						},
+					},
+				},
+			],
+			tool_choice: {
+				type: "function",
+				function: { name: "get_weather" },
+			},
+			response_format: {
+				type: "json_schema",
+				json_schema: {
+					name: "WeatherResponse",
+					schema: {
+						type: "object",
+						properties: {
+							condition: { type: "string" },
+						},
+						required: ["condition"],
+						additionalProperties: false,
+					},
+				},
+			},
+		});
+
+		if (!requestResult.success) {
+			console.error(requestResult.error.flatten());
+		}
+
+		expect(requestResult.success).toBe(true);
+
+		const request = requestResult.data!;
+
+		expect(request.model).toBe("deepseek-chat");
+
+		const response = ChatCompletionResponseSchema.parse({
+			id: "chatcmpl-123",
+			object: "chat.completion",
+			model: "deepseek-chat",
+			created: 1700000000,
+			system_fingerprint: "fp_abc123",
+			choices: [
+				{
+					index: 0,
+					message: {
+						role: "assistant",
+						content: "Hello!",
+						reasoning_content: [{ type: "text", text: "thinking" }],
+						tool_calls: [
+							{
+								id: "call_123",
+								type: "function",
+								function: {
+									name: "get_weather",
+									arguments: '{"location":"Hangzhou"}',
+								},
+							},
+						],
+					},
+					logprobs: {
+						content: [
+							{
+								token: "Hello",
+								logprob: -0.1,
+								top_logprobs: [
+									{
+										token: "Hello",
+										logprob: -0.1,
+									},
+								],
+							},
+						],
+					},
+					finish_reason: "stop",
+				},
+			],
+			usage: {
+				prompt_tokens: 10,
+				completion_tokens: 12,
+				total_tokens: 22,
+				prompt_cache_hit_tokens: 4,
+				prompt_cache_miss_tokens: 6,
+			},
+		});
+
+		expect(response.choices[0]?.message.content).toBe("Hello!");
+		expect(response.system_fingerprint).toBe("fp_abc123");
+	});
+
+	it("validates embedding payloads", () => {
+		const request = EmbeddingRequestSchema.parse({
+			model: "deepseek-embedding",
+			input: "Hello world",
+			encoding_format: "float",
+		});
+
+		expect(request.model).toBe("deepseek-embedding");
+
+		const response = EmbeddingResponseSchema.parse({
+			object: "list",
+			data: [
+				{
+					index: 0,
+					embedding: [0.1, 0.2, 0.3],
+					object: "embedding",
+				},
+			],
+			usage: { prompt_tokens: 3, total_tokens: 3 },
+		});
+
+		expect(response.data[0]?.embedding).toHaveLength(3);
+	});
+
+	it("validates speech synthesis payloads", () => {
+		const request = SpeechSynthesisRequestSchema.parse({
+			model: "deepseek-tts",
+			voice: "alloy",
+			input: "Hello there",
+			format: "mp3",
+		});
+
+		expect(request.voice).toBe("alloy");
+	});
+
+	it("validates model listings", () => {
+		const response = ListModelsResponseSchema.parse({
+			object: "list",
+			data: [
+				{
+					id: "deepseek-chat",
+					object: "model",
+					created: 1700000000,
+					owned_by: "deepseek",
+				},
+			],
+		});
+
+		expect(response.data[0]?.id).toBe("deepseek-chat");
+	});
+
+	it("validates user balance responses", () => {
+		const response = BalanceResponseSchema.parse({
+			is_available: true,
+			balance_infos: [
+				{
+					currency: "CNY",
+					balance: "100.00",
+					balance_name: "general",
+				},
+			],
+		});
+
+		expect(response.balance_infos[0]?.currency).toBe("CNY");
+	});
+});

--- a/app/api/deep-seek/zod-schemas.ts
+++ b/app/api/deep-seek/zod-schemas.ts
@@ -1,0 +1,255 @@
+import { z } from "zod";
+
+const TextContentPartSchema = z.object({
+	type: z.literal("text"),
+	text: z.string(),
+});
+
+const ImageUrlPartSchema = z.object({
+	type: z.literal("image_url"),
+	image_url: z.union([
+		z.string(),
+		z.object({
+			url: z.string(),
+			detail: z.enum(["low", "high", "auto"]).optional(),
+		}),
+	]),
+});
+
+const ToolResultPartSchema = z.object({
+	type: z.literal("tool_result"),
+	tool_call_id: z.string(),
+	content: z.union([z.string(), z.array(TextContentPartSchema)]).optional(),
+	is_error: z.boolean().optional(),
+});
+
+const ToolUsePartSchema = z.object({
+	type: z.literal("tool_use"),
+	id: z.string(),
+	name: z.string(),
+	input: z.unknown(),
+});
+
+const MessageContentPartSchema = z.union([
+	TextContentPartSchema,
+	ImageUrlPartSchema,
+	ToolResultPartSchema,
+	ToolUsePartSchema,
+]);
+
+const MessageContentSchema = z.union([
+	z.string(),
+	z.array(MessageContentPartSchema).min(1),
+]);
+
+const BaseMessageSchema = z
+	.object({
+		role: z.enum(["system", "user", "assistant", "tool"]),
+		content: MessageContentSchema,
+		name: z.string().optional(),
+		prefix: z.boolean().optional(),
+		tool_call_id: z.string().optional(),
+		metadata: z.object({}).catchall(z.unknown()).optional(),
+	})
+	.superRefine((message, ctx) => {
+		if (message.role === "tool" && !message.tool_call_id) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ["tool_call_id"],
+				message: "tool messages must include tool_call_id",
+			});
+		}
+
+		if (message.prefix && message.role !== "assistant") {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ["prefix"],
+				message: "prefix can only be set on assistant messages",
+			});
+		}
+	});
+
+const ToolCallSchema = z.object({
+	id: z.string(),
+	type: z.literal("function"),
+	function: z.object({
+		name: z.string(),
+		arguments: z.string(),
+		strict: z.boolean().optional(),
+	}),
+});
+
+export const ChatCompletionRequestSchema = z.object({
+	model: z.string(),
+	messages: z.array(BaseMessageSchema).min(1),
+	stream: z.boolean().optional(),
+	stream_options: z
+		.object({
+			include_usage: z.boolean().optional(),
+		})
+		.optional(),
+	temperature: z.number().min(0).max(2).optional(),
+	top_p: z.number().min(0).max(1).optional(),
+	max_tokens: z.number().int().positive().optional(),
+	stop: z.union([z.string(), z.array(z.string())]).optional(),
+	frequency_penalty: z.number().min(-2).max(2).optional(),
+	presence_penalty: z.number().min(-2).max(2).optional(),
+	logprobs: z.boolean().optional(),
+	top_logprobs: z.number().int().min(0).max(20).optional(),
+	tools: z
+		.array(
+			z.object({
+				type: z.literal("function"),
+				function: z.object({
+					name: z.string(),
+					description: z.string().optional(),
+					strict: z.boolean().optional(),
+					parameters: z.object({}).catchall(z.unknown()).optional(),
+				}),
+			}),
+		)
+		.optional(),
+	tool_choice: z
+		.union([
+			z.literal("auto"),
+			z.literal("none"),
+			z.object({
+				type: z.literal("function"),
+				function: z.object({ name: z.string() }),
+			}),
+		])
+		.optional(),
+	response_format: z
+		.union([
+			z.literal("json_object"),
+			z.object({
+				type: z.literal("json_schema"),
+				json_schema: z.object({
+					name: z.string(),
+					schema: z.object({}).catchall(z.unknown()),
+				}),
+			}),
+		])
+		.optional(),
+});
+
+const TokenLogprobSchema = z.object({
+	token: z.string(),
+	logprob: z.number(),
+	bytes: z.array(z.number()).optional(),
+});
+
+const LogprobItemSchema = TokenLogprobSchema.extend({
+	top_logprobs: z.array(TokenLogprobSchema).optional(),
+});
+
+const ChatCompletionChoiceSchema = z.object({
+	index: z.number().int(),
+	message: BaseMessageSchema.extend({
+		tool_calls: z.array(ToolCallSchema).optional(),
+		reasoning_content: z.array(z.any()).optional(),
+	}),
+	logprobs: z
+		.object({ content: z.array(LogprobItemSchema).optional() })
+		.optional(),
+	finish_reason: z.string().nullable(),
+});
+
+const UsageSchema = z.object({
+	prompt_tokens: z.number().int().nonnegative(),
+	completion_tokens: z.number().int().nonnegative().optional(),
+	total_tokens: z.number().int().nonnegative(),
+	prompt_cache_hit_tokens: z.number().int().nonnegative().optional(),
+	prompt_cache_miss_tokens: z.number().int().nonnegative().optional(),
+});
+
+export const ChatCompletionResponseSchema = z.object({
+	id: z.string(),
+	object: z.literal("chat.completion"),
+	model: z.string(),
+	created: z.number().int(),
+	system_fingerprint: z.string(),
+	choices: z.array(ChatCompletionChoiceSchema),
+	usage: UsageSchema.optional(),
+});
+
+export const ReasoningRequestSchema = ChatCompletionRequestSchema.extend({
+	reasoning: z
+		.object({
+			effort: z.enum(["low", "medium", "high"]).optional(),
+			planning: z.boolean().optional(),
+		})
+		.optional(),
+});
+
+export const ReasoningResponseSchema = ChatCompletionResponseSchema.extend({
+	reasoning_content: z.array(z.any()).optional(),
+});
+
+const EmbeddingInputSchema = z.union([
+	z.string(),
+	z.array(z.string()),
+	z.array(z.array(z.number())),
+]);
+
+export const EmbeddingRequestSchema = z.object({
+	model: z.string(),
+	input: EmbeddingInputSchema,
+	encoding_format: z.enum(["float", "base64"]).optional(),
+	dimensions: z.number().int().positive().optional(),
+});
+
+export const EmbeddingItemSchema = z.object({
+	index: z.number().int(),
+	embedding: z.array(z.number()),
+	object: z.literal("embedding"),
+});
+
+export const EmbeddingResponseSchema = z.object({
+	object: z.literal("list"),
+	data: z.array(EmbeddingItemSchema),
+	usage: z
+		.object({
+			prompt_tokens: z.number().int().nonnegative(),
+			total_tokens: z.number().int().nonnegative(),
+		})
+		.optional(),
+});
+
+export const SpeechSynthesisRequestSchema = z.object({
+	model: z.string(),
+	input: z.string(),
+	voice: z.string(),
+	format: z.enum(["mp3", "wav", "flac", "pcm"]).optional(),
+	speed: z.number().positive().max(4).optional(),
+});
+
+export const SpeechSynthesisResponseSchema = z.object({
+	audio: z.string(),
+	format: z.string(),
+});
+
+export const ModelSchema = z.object({
+	id: z.string(),
+	object: z.literal("model"),
+	created: z.number().int().optional(),
+	owned_by: z.string().optional(),
+	permissions: z.array(z.object({}).catchall(z.unknown())).optional(),
+});
+
+export const ListModelsResponseSchema = z.object({
+	object: z.literal("list"),
+	data: z.array(ModelSchema),
+});
+
+const BalanceInfoSchema = z.object({
+	balance_name: z.string(),
+	balance: z.union([z.string(), z.number()]).optional(),
+	currency: z.string().optional(),
+	expires_at: z.string().optional(),
+});
+
+export const BalanceResponseSchema = z.object({
+	is_available: z.boolean(),
+	balance_infos: z.array(BalanceInfoSchema),
+});


### PR DESCRIPTION
## Summary
- expand chat completion schemas to cover prefix messages, tool calls, logprobs, and system fingerprints documented by DeepSeek
- add balance response coverage and JSON schema validation utilities to match the docs folder capabilities
- extend the Vitest suite to exercise the richer request/response payloads and balance parsing

## Testing
- pnpm vitest run app/api/deep-seek/tests --environment node

------
https://chatgpt.com/codex/tasks/task_e_68e5c9d10a0083299e295d6f1a375750