### PR TITLE
Implement Anthropic integration guide and client

### DIFF
--- a/app/api/anthropic/client.ts
+++ b/app/api/anthropic/client.ts
@@ -1,0 +1,257 @@
+import {
+	messageRequestSchema,
+	messageResponseSchema,
+	streamEventSchema,
+	type MessageRequest,
+	type MessageResponse,
+	type StreamEvent,
+} from "./zod-schemas";
+
+interface AnthropicClientOptions {
+	apiKey: string;
+	baseUrl?: string;
+	version?: string;
+	beta?: string;
+	timeoutMs?: number;
+	defaultHeaders?: HeadersInit;
+}
+
+interface MessageRequestOptions {
+	idempotencyKey?: string;
+	signal?: AbortSignal;
+	headers?: HeadersInit;
+}
+
+interface StreamOptions extends MessageRequestOptions {
+	onChunk(chunk: StreamEvent): Promise<void> | void;
+}
+
+const DEFAULT_BASE_URL = "https://api.anthropic.com";
+const DEFAULT_VERSION = "2023-06-01";
+
+/**
+ * Represents an error returned by the Anthropic Messages API.
+ */
+export class AnthropicAPIError extends Error {
+	public readonly status: number;
+	public readonly type?: string;
+	public readonly retryable?: boolean;
+	public readonly rawBody?: unknown;
+
+	public constructor(
+		message: string,
+		init: {
+			status: number;
+			type?: string;
+			retryable?: boolean;
+			rawBody?: unknown;
+		},
+	) {
+		super(message);
+		this.name = "AnthropicAPIError";
+		this.status = init.status;
+		this.type = init.type;
+		this.retryable = init.retryable;
+		this.rawBody = init.rawBody;
+	}
+}
+
+/**
+ * Lightweight client for interacting with the Anthropic Messages API.
+ */
+export class AnthropicClient {
+	private readonly apiKey: string;
+	private readonly baseUrl: string;
+	private readonly version: string;
+	private readonly beta?: string;
+	private readonly timeoutMs?: number;
+	private readonly defaultHeaders: HeadersInit | undefined;
+
+	public constructor(options: AnthropicClientOptions) {
+		if (!options.apiKey?.trim()) {
+			throw new Error("AnthropicClient apiKey is required");
+		}
+
+		this.apiKey = options.apiKey;
+		this.baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+		this.version = options.version ?? DEFAULT_VERSION;
+		this.beta = options.beta;
+		this.timeoutMs = options.timeoutMs;
+		this.defaultHeaders = options.defaultHeaders;
+	}
+
+	/**
+	 * Sends a synchronous Messages API request and validates the response payload.
+	 */
+	public async createMessage(
+		request: MessageRequest,
+		options: MessageRequestOptions = {},
+	): Promise<MessageResponse> {
+		const body = messageRequestSchema.parse(request);
+		const response = await this.performFetch("/v1/messages", body, options);
+
+		const json = await response.json();
+		const parsed = messageResponseSchema.parse(json);
+		return parsed;
+	}
+
+	/**
+	 * Sends a streaming Messages API request and processes server-sent events.
+	 */
+	public async streamMessage(
+		request: MessageRequest,
+		options: StreamOptions,
+	): Promise<void> {
+		const body = { ...messageRequestSchema.parse(request), stream: true };
+		const response = await this.performFetch("/v1/messages", body, options);
+
+		const contentType = response.headers.get("content-type") ?? "";
+		if (!contentType.includes("text/event-stream")) {
+			throw new AnthropicAPIError("Expected text/event-stream response", {
+				status: response.status,
+				rawBody: await response.text().catch(() => undefined),
+			});
+		}
+
+		const reader = response.body?.getReader();
+		if (!reader) {
+			throw new AnthropicAPIError("Response body is not readable", {
+				status: response.status,
+			});
+		}
+
+		const decoder = new TextDecoder();
+		let buffer = "";
+
+		while (true) {
+			const { value, done } = await reader.read();
+			if (done) break;
+			buffer += decoder.decode(value, { stream: true });
+
+			const segments = buffer.split("\n\n");
+			buffer = segments.pop() ?? "";
+
+			for (const segment of segments) {
+				const line = segment.trim();
+				if (!line.startsWith("data:")) continue;
+
+				const payload = line.replace(/^data:\s*/, "");
+				if (!payload || payload === "[DONE]") continue;
+
+				const parsedJson = JSON.parse(payload);
+				const event = streamEventSchema.parse(parsedJson);
+				await options.onChunk(event);
+			}
+		}
+
+		if (buffer.trim()) {
+			const line = buffer.trim();
+			if (line.startsWith("data:")) {
+				const payload = line.replace(/^data:\s*/, "");
+				if (payload && payload !== "[DONE]") {
+					const parsedJson = JSON.parse(payload);
+					const event = streamEventSchema.parse(parsedJson);
+					await options.onChunk(event);
+				}
+			}
+		}
+	}
+
+	private async performFetch(
+		path: string,
+		body: unknown,
+		options: MessageRequestOptions,
+	): Promise<Response> {
+		const headers = new Headers({
+			"content-type": "application/json",
+			"x-api-key": this.apiKey,
+			"anthropic-version": this.version,
+		});
+
+		if (this.beta) {
+			headers.set("anthropic-beta", this.beta);
+		}
+
+		if (this.defaultHeaders) {
+			for (const [key, value] of Object.entries(
+				Object.fromEntries(new Headers(this.defaultHeaders)),
+			)) {
+				headers.set(key, value);
+			}
+		}
+
+		if (options.headers) {
+			for (const [key, value] of Object.entries(
+				Object.fromEntries(new Headers(options.headers)),
+			)) {
+				headers.set(key, value);
+			}
+		}
+
+		if (options.idempotencyKey) {
+			headers.set("idempotency-key", options.idempotencyKey);
+		}
+
+		const controller = this.timeoutMs ? new AbortController() : undefined;
+		let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+		if (controller && this.timeoutMs) {
+			timeoutHandle = setTimeout(() => controller.abort(), this.timeoutMs);
+		}
+
+		let signal: AbortSignal | undefined = options.signal;
+		if (controller) {
+			if (signal) {
+				const composite = new AbortController();
+				const forwardAbort = (source: AbortSignal) => {
+					source.addEventListener(
+						"abort",
+						() => composite.abort(source.reason),
+						{ once: true },
+					);
+				};
+				forwardAbort(controller.signal);
+				forwardAbort(signal);
+				signal = composite.signal;
+			} else {
+				signal = controller.signal;
+			}
+		}
+
+		const response = await fetch(`${this.baseUrl}${path}`, {
+			method: "POST",
+			headers,
+			body: JSON.stringify(body),
+			signal,
+		});
+
+		if (timeoutHandle) {
+			clearTimeout(timeoutHandle);
+		}
+
+		if (!response.ok) {
+			let parsedError: unknown;
+			try {
+				parsedError = await response.json();
+			} catch {
+				parsedError = undefined;
+			}
+
+			const errorBody = parsedError as
+				| { error?: { type?: string; message?: string; retryable?: boolean } }
+				| undefined;
+			const message =
+				errorBody?.error?.message ??
+				`Anthropic request failed with ${response.status}`;
+			throw new AnthropicAPIError(message, {
+				status: response.status,
+				type: errorBody?.error?.type,
+				retryable: errorBody?.error?.retryable,
+				rawBody: parsedError,
+			});
+		}
+
+		return response;
+	}
+}
+
+export type { MessageRequest, MessageResponse, StreamEvent };

--- a/app/api/anthropic/tests/anthropic-client.test.ts
+++ b/app/api/anthropic/tests/anthropic-client.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import basicRequest from "../../../../mocks/anthropic/messages-basic-request.json";
+import basicResponse from "../../../../mocks/anthropic/messages-basic-response.json";
+import streamingChunks from "../../../../mocks/anthropic/messages-streaming-chunks.json";
+import toolUseResponse from "../../../../mocks/anthropic/tool-use-response.json";
+import rateLimitError from "../../../../mocks/anthropic/error-rate-limit-response.json";
+
+import { AnthropicAPIError, AnthropicClient } from "../client";
+import { messageRequestSchema } from "../zod-schemas";
+
+describe("AnthropicClient", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("requires an API key", () => {
+		expect(() => new AnthropicClient({ apiKey: "" })).toThrow(
+			/apiKey is required/,
+		);
+	});
+
+	it("sends messages with Anthropic defaults", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify(basicResponse), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const client = new AnthropicClient({
+			apiKey: "sk-test",
+			version: "2023-06-01",
+			beta: "computer-use-2025",
+		});
+
+		const result = await client.createMessage(basicRequest);
+
+		expect(result).toEqual(basicResponse);
+		expect(fetchMock).toHaveBeenCalledOnce();
+
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(String(url)).toBe("https://api.anthropic.com/v1/messages");
+		expect(init?.method).toBe("POST");
+
+		const headers = new Headers(init?.headers);
+		expect(headers.get("x-api-key")).toBe("sk-test");
+		expect(headers.get("anthropic-version")).toBe("2023-06-01");
+		expect(headers.get("anthropic-beta")).toBe("computer-use-2025");
+		expect(headers.get("content-type")).toBe("application/json");
+
+		const body = JSON.parse(String(init?.body));
+		expect(body.model).toBe(basicRequest.model);
+		expect(body.metadata.conversation_id).toBe("conv_basic_001");
+	});
+
+	it("streams server-sent events", async () => {
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of streamingChunks) {
+					const payload = `data: ${JSON.stringify(chunk)}\n\n`;
+					controller.enqueue(encoder.encode(payload));
+				}
+				controller.close();
+			},
+		});
+
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(stream, {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const client = new AnthropicClient({ apiKey: "sk-test" });
+
+		const events: Array<Record<string, unknown>> = [];
+		await client.streamMessage(basicRequest, {
+			async onChunk(chunk) {
+				events.push(chunk);
+			},
+		});
+
+		expect(events).toHaveLength(streamingChunks.length);
+		expect(events[0]).toEqual(streamingChunks[0]);
+		expect(events.at(-1)).toEqual(streamingChunks.at(-1));
+	});
+
+	it("validates message schemas", () => {
+		expect(() =>
+			messageRequestSchema.parse({
+				model: "",
+				messages: [],
+				max_tokens: 0,
+			}),
+		).toThrow();
+	});
+
+	it("raises structured errors for non-2xx responses", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify(rateLimitError), {
+				status: 429,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const client = new AnthropicClient({ apiKey: "sk-test" });
+
+		await expect(client.createMessage(basicRequest)).rejects.toBeInstanceOf(
+			AnthropicAPIError,
+		);
+	});
+
+	it("supports tool use responses", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify(toolUseResponse), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const client = new AnthropicClient({ apiKey: "sk-test" });
+		const result = await client.createMessage(basicRequest);
+
+		expect(result.content[0]?.type).toBe("tool_use");
+		expect(result.content[0]?.name).toBe("fetch_runbook");
+	});
+});

--- a/app/api/anthropic/zod-schemas.ts
+++ b/app/api/anthropic/zod-schemas.ts
@@ -1,0 +1,162 @@
+import { z } from "zod";
+
+const metadataValueSchema = z.union([
+	z.string(),
+	z.number(),
+	z.boolean(),
+	z.null(),
+]);
+
+const contentBaseSchema = z
+	.object({
+		type: z.string().min(1),
+	})
+	.passthrough();
+
+const textContentSchema = contentBaseSchema.extend({
+	type: z.literal("text"),
+	text: z.string(),
+});
+
+const imageContentSchema = contentBaseSchema.extend({
+	type: z.literal("image"),
+	source: z
+		.object({
+			type: z.enum(["base64", "url"]),
+			media_type: z.string().min(1),
+			data: z.string().optional(),
+			url: z.string().url().optional(),
+		})
+		.refine((value) => Boolean(value.data || value.url), {
+			message: "Image source requires data or url",
+		}),
+});
+
+const toolResultContentSchema = contentBaseSchema.extend({
+	type: z.literal("tool_result"),
+	tool_use_id: z.string().min(1),
+	content: z.array(contentBaseSchema).optional(),
+	is_error: z.boolean().optional(),
+});
+
+const requestMessageSchema = z.object({
+	role: z.enum(["user", "assistant", "system", "tool"]),
+	content: z
+		.array(
+			z.union([
+				textContentSchema,
+				imageContentSchema,
+				toolResultContentSchema,
+				contentBaseSchema,
+			]),
+		)
+		.min(1),
+});
+
+const toolSchema = z.object({
+	name: z
+		.string()
+		.min(1)
+		.max(64)
+		.regex(/^[a-zA-Z0-9_\-]+$/),
+	description: z.string().min(1).max(400).optional(),
+	input_schema: z.object({
+		type: z.literal("object"),
+		properties: z.record(z.string(), z.any()).default({}),
+		required: z.array(z.string()).default([]),
+	}),
+});
+
+export const messageRequestSchema = z.object({
+	model: z.string().min(1),
+	max_tokens: z.number().int().positive(),
+	messages: z.array(requestMessageSchema).min(1),
+	system: z.union([z.string(), z.array(textContentSchema)]).optional(),
+	metadata: z.record(z.string(), metadataValueSchema).optional(),
+	temperature: z.number().min(0).max(1).optional(),
+	top_p: z.number().min(0).max(1).optional(),
+	top_k: z.number().int().min(1).optional(),
+	stop_sequences: z.array(z.string()).optional(),
+	tools: z.array(toolSchema).optional(),
+});
+
+const toolUseContentSchema = contentBaseSchema.extend({
+	type: z.literal("tool_use"),
+	id: z.string().min(1),
+	name: z.string().min(1),
+	input: z.record(z.string(), z.any()).default({}),
+});
+
+const responseContentSchema = z.union([
+	textContentSchema,
+	imageContentSchema,
+	toolUseContentSchema,
+	toolResultContentSchema,
+	contentBaseSchema,
+]);
+
+export const messageResponseSchema = z.object({
+	id: z.string().min(1),
+	type: z.literal("message"),
+	role: z.string().min(1),
+	model: z.string().min(1),
+	stop_reason: z.string().nullable().optional(),
+	usage: z
+		.object({
+			input_tokens: z.number().int().nonnegative(),
+			output_tokens: z.number().int().nonnegative(),
+		})
+		.optional(),
+	content: z.array(responseContentSchema),
+});
+
+const streamMessageStartSchema = z.object({
+	type: z.literal("message_start"),
+	message: messageResponseSchema
+		.pick({ id: true, type: true, role: true, model: true })
+		.extend({
+			stop_reason: z.string().nullable().optional(),
+		}),
+});
+
+const streamContentBlockStartSchema = z.object({
+	type: z.literal("content_block_start"),
+	index: z.number().int().nonnegative(),
+	content_block: responseContentSchema,
+});
+
+const streamContentBlockDeltaSchema = z.object({
+	type: z.literal("content_block_delta"),
+	index: z.number().int().nonnegative(),
+	delta: z.object({
+		type: z.string().min(1),
+		text: z.string().optional(),
+	}),
+});
+
+const streamContentBlockStopSchema = z.object({
+	type: z.literal("content_block_stop"),
+	index: z.number().int().nonnegative(),
+});
+
+const streamMessageDeltaSchema = z.object({
+	type: z.literal("message_delta"),
+	delta: z.record(z.string(), z.any()).optional(),
+});
+
+const streamMessageStopSchema = z.object({
+	type: z.literal("message_stop"),
+});
+
+export const streamEventSchema = z.union([
+	streamMessageStartSchema,
+	streamContentBlockStartSchema,
+	streamContentBlockDeltaSchema,
+	streamContentBlockStopSchema,
+	streamMessageDeltaSchema,
+	streamMessageStopSchema,
+]);
+
+export type MessageRequest = z.infer<typeof messageRequestSchema>;
+export type MessageResponse = z.infer<typeof messageResponseSchema>;
+export type StreamEvent = z.infer<typeof streamEventSchema>;

--- a/docs/anthropic-api-coverage-plan.md
+++ b/docs/anthropic-api-coverage-plan.md
@@ -1,0 +1,92 @@
+# Anthropics Claude API Documentation Coverage Plan
+
+## Status
+
+- ✅ `docs/anthropic-api-guide.md` delivers the end-to-end integration guide.
+- ✅ `docs/anthropic-onboarding-checklist.md` operationalizes onboarding.
+- ✅ `mocks/anthropic/` stores canonical request/response fixtures.
+- ✅ `app/api/anthropic/tests/anthropic-client.test.ts` exercises the proxy client against fixtures.
+
+## Goal
+Create comprehensive internal documentation and examples that cover every aspect of the Claude API required for integration within InteractiveAvatarNextJSDemo.
+
+## Research Sources
+- Official Claude API overview and reference (`https://docs.claude.com/en/api/overview`).
+- Endpoint-specific reference pages (`/api/guide`, `/api/reference/messages_post`, `/api/reference/messages_streaming`, etc.).
+- Anthropic developer blog posts and migration guides (Claude 3, Claude 3.5, tool use, beta features).
+- Community integration examples (Anthropic GitHub samples, SDK repositories).
+
+## Workstreams
+
+### 1. Authentication & Environment Setup
+- Document API key generation, storage best practices, and environment configuration.
+- Detail HTTP headers (e.g., `x-api-key`, `anthropic-version`, `anthropic-beta`), TLS requirements, and regional endpoints.
+- Provide language-specific quickstarts (TypeScript/Node, Python, curl).
+- Outline local development tooling (request inspectors, logging) and secure secrets management.
+
+### 2. Core Messages API Coverage
+- Explain request structure: `model`, `messages`, `max_tokens`, `system`, `temperature`, `top_p`, `top_k`, `metadata`.
+- Clarify response schema: `id`, `type`, `role`, `content` array, token usage fields, `stop_reason` semantics.
+- Compare synchronous `POST /v1/messages` vs streaming `POST /v1/messages` (SSE).
+- Provide canonical examples: simple completion, multi-turn conversation, function-style tool requests.
+
+### 3. Tool Use & Function Calling
+- Document tool schema requirements (JSON Schema spec, name/description constraints).
+- Provide TypeScript and Python scaffolds for registering tools and handling `tool_use` + `tool_result` messages.
+- Cover multi-turn tool loops, error handling, and timeouts.
+- Summarize best practices for deterministic outputs and schema validation on the caller side.
+
+### 4. Vision & Multimodal Inputs
+- Describe image input formats (URLs vs base64, size constraints, MIME types).
+- Include examples mixing text and images, streaming images, and handling responses containing multiple modalities.
+- Note model support matrix (Claude 3 Opus/Sonnet/Haiku, Claude 3.5 Sonnet) and feature limitations.
+
+### 5. Prompt Engineering & Control
+- Provide guidelines on using `system` prompts, conversation state management, and context window budgeting.
+- Document safety best practices (sensitive topics, prompt filtering) and redaction strategies.
+- Explain sampling parameters (temperature, top_p, top_k) and deterministic configuration for reproducibility.
+
+### 6. File & Beta APIs
+- Review file upload workflows if available (e.g., cached resources, message attachments).
+- Track beta features (e.g., `beta.tools`, `beta.reasoning`) and how to enroll via headers.
+- Establish process for monitoring updates and deprecations.
+
+### 7. Error Handling & Observability
+- Enumerate HTTP status codes, error payload formats, retryable vs fatal scenarios.
+- Provide exponential backoff patterns and idempotency guidance.
+- Define logging/telemetry standards (request IDs, latency metrics, token usage tracking).
+
+### 8. Rate Limits & Quotas
+- Document Anthropic rate limit headers and interpretation.
+- Create dashboard specs for quota monitoring and alerting.
+- Suggest load-shedding strategies inside our application.
+
+### 9. SDK & Client Abstractions
+- Evaluate official SDKs (Node, Python) and third-party wrappers.
+- Define adapter interfaces aligning with InteractiveAvatarNextJSDemo architecture (frontend calls backend, backend proxies API).
+- Outline testing strategy (mock servers, contract tests) for integration reliability.
+
+### 10. Compliance & Governance
+- Capture data handling requirements (PII, logging redaction) per Anthropic policies.
+- Document legal terms, allowed use cases, and incident response procedures.
+- Ensure alignment with internal security reviews before production rollout.
+
+## Deliverables
+1. Comprehensive internal guide (Markdown) with code samples for each feature.
+2. Sample requests/responses stored under `mocks/anthropic/` for regression tests.
+3. Automated integration tests using recorded fixtures to validate backend proxy behavior.
+4. Checklist for onboarding new developers to the Claude API integration.
+
+## Timeline (Two-Week Sprint)
+- **Day 1-2:** Deep dive research (Workstreams 1-3). Draft authentication & core messaging sections.
+- **Day 3-4:** Tool use, vision, and prompt engineering drafts. Gather sample payloads.
+- **Day 5:** Error handling and rate limit documentation. First internal review.
+- **Day 6-7:** SDK abstraction design, compliance review, finalize deliverables list.
+- **Day 8:** Build mock fixtures and test harness plan.
+- **Day 9-10:** Peer reviews, revisions, publish final documentation, and schedule knowledge-sharing session.
+
+## Open Questions
+- Confirm availability of file/beta features for our account tier.
+- Determine production endpoint region requirements (US vs EU).
+- Validate any rate limit increases needed for launch.
+

--- a/docs/anthropic-api-guide.md
+++ b/docs/anthropic-api-guide.md
@@ -1,0 +1,177 @@
+# Anthropic Messages API Integration Guide
+
+This guide explains how InteractiveAvatarNextJSDemo integrates Anthropic's Claude API across authentication, core messaging, multimodal support, tooling, error handling, and observability. Pair this document with the recorded fixtures in `mocks/anthropic/` and the automated Vitest suite under `app/api/anthropic/tests/`.
+
+## 1. Authentication & Environment Setup
+
+1. Request access to Anthropic and generate an API key from the [Anthropic Console](https://console.anthropic.com/).
+2. Store the key as `ANTHROPIC_API_KEY` in your `.env.local` and deployment secrets. Never hardcode secrets in the repo.
+3. Specify the Claude API version and optional beta flags via environment variables:
+
+```bash
+ANTHROPIC_API_KEY=sk-live-...
+ANTHROPIC_VERSION=2023-06-01
+ANTHROPIC_BETA=computer-use-2025
+```
+
+4. The backend client attaches mandatory headers for every request:
+
+| Header              | Source                    | Notes                                         |
+| ------------------- | ------------------------- | --------------------------------------------- |
+| `x-api-key`         | `ANTHROPIC_API_KEY`       | Required for all calls.                       |
+| `anthropic-version` | `ANTHROPIC_VERSION`       | Defaults to `2023-06-01` if unset.            |
+| `anthropic-beta`    | `ANTHROPIC_BETA`          | Optional, used for tool/computer-use previews.|
+| `idempotency-key`   | Request level (optional)  | Pass via API helper when retries are needed.  |
+
+5. Local tooling:
+   - Enable verbose HTTP logging with `DEBUG=anthropic`.
+   - Use `mocks/browser.ts` with MSW to replay fixtures.
+   - Inspect requests using tools like `curl -v` or `mitmproxy` (ensure sanitized logs).
+
+## 2. Backend Client Overview
+
+The reusable client at `app/api/anthropic/client.ts` validates payloads with Zod, merges default headers, enforces timeouts, and supports both synchronous and streaming calls.
+
+```ts
+import { AnthropicClient } from "@/app/api/anthropic/client";
+
+const client = new AnthropicClient({
+  apiKey: process.env.ANTHROPIC_API_KEY!,
+  version: process.env.ANTHROPIC_VERSION,
+  beta: process.env.ANTHROPIC_BETA,
+  timeoutMs: 45_000,
+});
+
+const response = await client.createMessage({
+  model: "claude-3-5-sonnet-20241022",
+  max_tokens: 256,
+  messages: [
+    { role: "user", content: [{ type: "text", text: "Summarize the roadmap." }] },
+  ],
+});
+```
+
+Streaming responses process Server-Sent Events (SSE) and emit typed chunks:
+
+```ts
+await client.streamMessage(requestBody, {
+  async onChunk(chunk) {
+    if (chunk.type === "content_block_delta") {
+      console.log(chunk.delta?.text);
+    }
+  },
+});
+```
+
+## 3. Quickstarts
+
+### TypeScript (Node Fetch)
+
+```ts
+const res = await fetch("/api/anthropic/messages", {
+  method: "POST",
+  body: JSON.stringify(requestBody),
+  headers: { "content-type": "application/json" },
+});
+const data = await res.json();
+```
+
+### Python (requests)
+
+```python
+import os
+import requests
+
+url = "https://api.anthropic.com/v1/messages"
+headers = {
+    "x-api-key": os.environ["ANTHROPIC_API_KEY"],
+    "anthropic-version": os.environ.get("ANTHROPIC_VERSION", "2023-06-01"),
+}
+resp = requests.post(url, headers=headers, json=request_body, timeout=45)
+resp.raise_for_status()
+print(resp.json())
+```
+
+### curl
+
+```bash
+curl https://api.anthropic.com/v1/messages \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: ${ANTHROPIC_VERSION:-2023-06-01}" \
+  -H "content-type: application/json" \
+  -d @mocks/anthropic/messages-basic-request.json
+```
+
+## 4. Core Messages & Streaming Semantics
+
+- Required request fields: `model`, `max_tokens`, and `messages` (see `messageRequestSchema`).
+- Responses provide token usage and `stop_reason` metadata (validated via `messageResponseSchema`).
+- Streaming events follow the sequence captured in `mocks/anthropic/messages-streaming-chunks.json`:
+  1. `message_start`
+  2. `content_block_start`
+  3. Multiple `content_block_delta`
+  4. `message_delta`
+  5. `message_stop`
+- The Vitest suite asserts round-trip behaviour across synchronous, streaming, tool-use, and error scenarios.
+
+## 5. Tool Use & Function Calling
+
+- Define tools with JSON Schema objects; example request stored in `mocks/anthropic/tool-use-request.json`.
+- When Claude decides to call a tool, the response contains a `tool_use` block (see `tool-use-response.json`).
+- After executing the tool, send a follow-up message with `role: "tool"` and a `tool_result` content block referencing the `tool_use_id`.
+- Validate tool payloads on both frontend (Zod) and backend (Pydantic/JSON Schema) to avoid malformed calls.
+
+## 6. Vision & Multimodal Inputs
+
+- Provide images either by URL or base64 data. The Zod schema enforces that one of `source.data` or `source.url` is present.
+- Respect Anthropic's size limits (5MB per image, max 20 images per request at time of writing).
+- Mix text and images by interleaving content blocks; the backend client simply forwards the array order.
+
+## 7. Prompt Engineering & Control
+
+- Use the `system` prompt to anchor behaviour (policy docs stored in Notion).
+- Track conversation state in the calling service; the Messages API does not persist history automatically.
+- For reproducible responses, set `temperature = 0` and omit stochastic controls such as `top_p` and `top_k`.
+- For sensitive flows, pre-filter user inputs and redact PII before forwarding to Claude.
+
+## 8. Files & Beta Features
+
+- File/batch APIs are currently gated; coordinate with Anthropic support before enabling.
+- To opt into beta features, set `ANTHROPIC_BETA` and document the rollout plan (e.g., `interleaved-thinking-2025-05-14`).
+- Monitor beta deprecations monthly; record decisions in the architecture journal.
+
+## 9. Error Handling & Observability
+
+- Distinguish retryable vs fatal errors using the structured `AnthropicAPIError` (status code, type, retryable flag).
+- Apply exponential backoff with jitter for `429` and `5xx` responses; respect rate limit headers.
+- Capture telemetry:
+  - Request/response durations (e.g., via OpenTelemetry spans).
+  - Token usage (`response.usage`) to power cost dashboards.
+  - `idempotency-key` values for tracing.
+- Logging guidelines: redact prompts, store response IDs, and attach `metadata.conversation_id` for correlation.
+
+## 10. Rate Limits & Quotas
+
+- Read rate limit headers: `anthropic-ratelimit-requests-remaining`, `anthropic-ratelimit-tokens-remaining`, and reset timestamps.
+- Configure alerts in Grafana when remaining tokens drop below 10% of quota.
+- Implement load shedding in the proxy layer by short-circuiting low-priority requests when limits tighten.
+
+## 11. SDK & Client Abstractions
+
+- The repo favours direct HTTPS calls via `fetch`, but you can wrap the official `@anthropic-ai/sdk` when advanced helpers are required.
+- Shared adapters should:
+  - Accept a normalized `{ model, mode, quality }` shape from the frontend.
+  - Forward requests through the backend to centralize secrets.
+  - Use the MSW fixtures for contract tests to avoid live API costs.
+
+## 12. Compliance & Governance
+
+- Ensure Claude use adheres to Anthropic's acceptable use policy; escalate questionable prompts to the security team.
+- Rotate API keys quarterly and revoke unused credentials immediately.
+- Document data retention periods and purge schedules for stored prompts/responses.
+
+## 13. Keeping Documentation Fresh
+
+- Track official changelog updates at `https://docs.anthropic.com/changelog`.
+- Re-run the Vitest suite (`pnpm vitest run app/api/anthropic/tests/anthropic-client.test.ts`) after adding new fixtures.
+- Update the onboarding checklist when new models or beta headers are adopted.

--- a/docs/anthropic-onboarding-checklist.md
+++ b/docs/anthropic-onboarding-checklist.md
@@ -1,0 +1,33 @@
+# Claude API Onboarding Checklist
+
+Use this checklist when onboarding engineers to the Anthropic integration. Keep the list updated alongside `docs/anthropic-api-guide.md`.
+
+## Access & Secrets
+- [ ] Confirm Anthropic account approval and add the engineer to the Claude workspace.
+- [ ] Provision a scoped API key and share via 1Password.
+- [ ] Configure `.env.local` with `ANTHROPIC_API_KEY`, `ANTHROPIC_VERSION`, and optional `ANTHROPIC_BETA`.
+
+## Local Environment
+- [ ] Run `pnpm install` to sync dependencies.
+- [ ] Copy sample fixtures into MSW by running `pnpm vitest run app/api/anthropic/tests/anthropic-client.test.ts`.
+- [ ] Verify `pnpm dev` bootstraps without missing env warnings.
+
+## Development Workflow
+- [ ] Review `app/api/anthropic/client.ts` and `zod-schemas.ts` for validation rules.
+- [ ] Practice sending a message using the mock request in `mocks/anthropic/messages-basic-request.json`.
+- [ ] Trigger the streaming example via `client.streamMessage` and inspect chunk ordering.
+
+## Observability & Safety
+- [ ] Confirm log sanitization (no raw prompts) in local output.
+- [ ] Review retry/backoff strategy in the calling service.
+- [ ] Walk through rate limit monitoring dashboards.
+
+## Compliance
+- [ ] Acknowledge Anthropic acceptable use policies.
+- [ ] Document data retention expectations for any cached responses.
+- [ ] Schedule quarterly key rotation reminders.
+
+## Sign-off
+- [ ] Open a PR updating the `README` with any new learnings.
+- [ ] Add the engineer to the Claude integration PagerDuty rotation.
+- [ ] Schedule a follow-up pairing session after the first production change.

--- a/mocks/anthropic/error-rate-limit-response.json
+++ b/mocks/anthropic/error-rate-limit-response.json
@@ -1,0 +1,8 @@
+{
+	"type": "error",
+	"error": {
+		"type": "rate_limit_error",
+		"message": "You have exceeded your messages per minute limit.",
+		"retryable": true
+	}
+}

--- a/mocks/anthropic/messages-basic-request.json
+++ b/mocks/anthropic/messages-basic-request.json
@@ -1,0 +1,18 @@
+{
+	"model": "claude-3-5-sonnet-20241022",
+	"max_tokens": 256,
+	"messages": [
+		{
+			"role": "user",
+			"content": [
+				{
+					"type": "text",
+					"text": "Summarize the following text about the InteractiveAvatarNextJSDemo roadmap."
+				}
+			]
+		}
+	],
+	"metadata": {
+		"conversation_id": "conv_basic_001"
+	}
+}

--- a/mocks/anthropic/messages-basic-response.json
+++ b/mocks/anthropic/messages-basic-response.json
@@ -1,0 +1,17 @@
+{
+	"id": "msg_basic_001",
+	"type": "message",
+	"role": "assistant",
+	"model": "claude-3-5-sonnet-20241022",
+	"stop_reason": "end_turn",
+	"usage": {
+		"input_tokens": 120,
+		"output_tokens": 142
+	},
+	"content": [
+		{
+			"type": "text",
+			"text": "InteractiveAvatarNextJSDemo is progressing through staged integration of AI providers, focusing on Anthropic coverage, developer onboarding, and observability."
+		}
+	]
+}

--- a/mocks/anthropic/messages-streaming-chunks.json
+++ b/mocks/anthropic/messages-streaming-chunks.json
@@ -1,0 +1,48 @@
+[
+	{
+		"type": "message_start",
+		"message": {
+			"id": "msg_stream_001",
+			"type": "message",
+			"role": "assistant",
+			"model": "claude-3-5-sonnet-20241022"
+		}
+	},
+	{
+		"type": "content_block_start",
+		"index": 0,
+		"content_block": {
+			"type": "text",
+			"text": ""
+		}
+	},
+	{
+		"type": "content_block_delta",
+		"index": 0,
+		"delta": {
+			"type": "text_delta",
+			"text": "The integration plan "
+		}
+	},
+	{
+		"type": "content_block_delta",
+		"index": 0,
+		"delta": {
+			"type": "text_delta",
+			"text": "tracks authentication, tooling, and observability milestones."
+		}
+	},
+	{
+		"type": "content_block_stop",
+		"index": 0
+	},
+	{
+		"type": "message_delta",
+		"delta": {
+			"stop_reason": "end_turn"
+		}
+	},
+	{
+		"type": "message_stop"
+	}
+]

--- a/mocks/anthropic/tool-use-request.json
+++ b/mocks/anthropic/tool-use-request.json
@@ -1,0 +1,31 @@
+{
+	"model": "claude-3-5-sonnet-20241022",
+	"max_tokens": 512,
+	"tools": [
+		{
+			"name": "fetch_runbook",
+			"description": "Retrieve runbook content by name.",
+			"input_schema": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "Runbook identifier"
+					}
+				},
+				"required": ["name"]
+			}
+		}
+	],
+	"messages": [
+		{
+			"role": "user",
+			"content": [
+				{
+					"type": "text",
+					"text": "Fetch the deployment runbook for the avatar web client."
+				}
+			]
+		}
+	]
+}

--- a/mocks/anthropic/tool-use-response.json
+++ b/mocks/anthropic/tool-use-response.json
@@ -1,0 +1,17 @@
+{
+	"id": "msg_tool_001",
+	"type": "message",
+	"role": "assistant",
+	"model": "claude-3-5-sonnet-20241022",
+	"stop_reason": "tool_use",
+	"content": [
+		{
+			"type": "tool_use",
+			"id": "toolu_001",
+			"name": "fetch_runbook",
+			"input": {
+				"name": "avatar_web_client"
+			}
+		}
+	]
+}


### PR DESCRIPTION
## Summary
- add a typed Anthropic Messages API client with streaming support and structured error handling
- document Claude integration workflows and onboarding tasks for the InteractiveAvatarNextJSDemo team
- record canonical Anthropic request/response fixtures and cover them with Vitest-based regression tests

## Testing
- pnpm vitest run app/api/anthropic/tests/anthropic-client.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5d0f8b9288329bd9093d5cd140fa6