### PR TITLE
feat: add modular Anthropic SDK client

### DIFF
--- a/app/api/anthropic/modules/__tests__/registry.test.ts
+++ b/app/api/anthropic/modules/__tests__/registry.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+	buildOperationRegistry,
+	matchOperationByPath,
+} from "../operation-registry";
+import { DEFAULT_OPERATIONS } from "../operations";
+import {
+	AnthropicSDKClient,
+	type AnthropicSDKClientConfig,
+	AnthropicHttpError,
+} from "../../sdk/anthropic-sdk-client";
+
+const CREATE_MESSAGE_OPERATION = "createMessage";
+const RETRIEVE_BATCH_OPERATION = "retrieveMessageBatch";
+
+describe("Anthropic modular SDK", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("builds a registry containing documented operations", () => {
+		const registry = buildOperationRegistry(DEFAULT_OPERATIONS);
+
+		expect(registry.byId.has(CREATE_MESSAGE_OPERATION)).toBe(true);
+		expect(registry.byId.has(RETRIEVE_BATCH_OPERATION)).toBe(true);
+	});
+
+	it("exposes modules grouped by tag", async () => {
+		const client = createClient();
+		const modules = await client.modules();
+
+		expect(modules.messages).toBeDefined();
+		expect(modules.messages.tag).toBe("Messages");
+		expect(typeof modules.messages[CREATE_MESSAGE_OPERATION]).toBe("function");
+	});
+
+	it("throws when calling unknown operations", async () => {
+		const client = createClient();
+
+		await expect(client.call("unknownOperation" as never)).rejects.toThrow(
+			/Unknown Anthropic operation/,
+		);
+	});
+
+	it("matches operations by method and path", () => {
+		const registry = buildOperationRegistry(DEFAULT_OPERATIONS);
+
+		const messagesMatch = matchOperationByPath(registry, "post", "/messages");
+		expect(messagesMatch?.operation.id).toBe(CREATE_MESSAGE_OPERATION);
+
+		const batchMatch = matchOperationByPath(
+			registry,
+			"get",
+			"/messages/batches/batch_123",
+		);
+
+		expect(batchMatch?.operation.id).toBe(RETRIEVE_BATCH_OPERATION);
+		expect(batchMatch?.pathParams.batchId).toBe("batch_123");
+	});
+
+	it("resolves operations from the client by path", async () => {
+		const client = createClient();
+
+		const resolved = await client.resolveOperation(
+			"get",
+			"/messages/batches/batch_456",
+		);
+
+		expect(resolved?.operation.id).toBe(RETRIEVE_BATCH_OPERATION);
+		expect(resolved?.pathParams.batchId).toBe("batch_456");
+	});
+
+	it("attaches Anthropic headers when performing requests", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const client = createClient({
+			version: "2023-06-01",
+			beta: "computer-use-2025",
+			requestDefaults: {
+				headers: { "anthropic-beta": "should-be-overridden" },
+			},
+		});
+
+		await client.call(CREATE_MESSAGE_OPERATION, {
+			body: { model: "claude-3-sonnet", messages: [], max_tokens: 1 },
+		});
+
+		expect(fetchMock).toHaveBeenCalledOnce();
+		const [url, init] = fetchMock.mock.calls[0];
+
+		expect(url).toBe("https://api.anthropic.com/v1/messages");
+		expect(init?.method).toBe("POST");
+
+		const headers = new Headers(init?.headers);
+		expect(headers.get("x-api-key")).toBe("sk-test");
+		expect(headers.get("anthropic-version")).toBe("2023-06-01");
+		expect(headers.get("anthropic-beta")).toBe("computer-use-2025");
+		expect(headers.get("content-type")).toBe("application/json");
+	});
+
+	it("wraps failed responses in AnthropicHttpError", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ error: { message: "nope" } }), {
+				status: 401,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const client = createClient();
+
+		await expect(
+			client.call(CREATE_MESSAGE_OPERATION, {
+				body: { model: "claude-3", messages: [], max_tokens: 1 },
+			}),
+		).rejects.toBeInstanceOf(AnthropicHttpError);
+	});
+});
+
+function createClient(config: Partial<AnthropicSDKClientConfig> = {}) {
+	return new AnthropicSDKClient({
+		apiKey: "sk-test",
+		version: "2023-05-30",
+		...config,
+	});
+}

--- a/app/api/anthropic/modules/http-client.ts
+++ b/app/api/anthropic/modules/http-client.ts
@@ -1,0 +1,213 @@
+import { URLSearchParams } from "node:url";
+
+import type { HttpMethod } from "./operation-registry";
+import { isPlainObject } from "./utils";
+
+const JSON_CONTENT_TYPE = "application/json";
+
+export interface HttpClientConfig {
+	readonly baseUrl: string;
+	readonly apiKey: string;
+	readonly version: string;
+	readonly beta?: string;
+	readonly defaultHeaders?: Record<string, string>;
+}
+
+export interface RequestOptions {
+	readonly method: HttpMethod;
+	readonly path: string;
+	readonly query?: Record<string, unknown>;
+	readonly headers?: Record<string, string>;
+	readonly body?: unknown;
+	readonly signal?: AbortSignal;
+}
+
+export class HttpClient {
+	private readonly baseUrl: string;
+	private readonly apiKey: string;
+	private readonly version: string;
+	private readonly beta?: string;
+	private readonly defaultHeaders: Record<string, string>;
+
+	constructor(config: HttpClientConfig) {
+		this.baseUrl = config.baseUrl;
+		this.apiKey = config.apiKey;
+		this.version = config.version;
+		this.beta = config.beta;
+		this.defaultHeaders = config.defaultHeaders ?? {};
+	}
+
+	async request<T = unknown>(options: RequestOptions): Promise<T> {
+		const response = await this.requestRaw(options);
+		return this.parseResponse<T>(response);
+	}
+
+	async requestRaw({
+		method,
+		path,
+		query,
+		headers,
+		body,
+		signal,
+	}: RequestOptions): Promise<Response> {
+		const url = this.composeUrl(path, query);
+		const composedHeaders = this.composeHeaders(headers, body);
+		const response = await fetch(url, {
+			method: method.toUpperCase(),
+			headers: composedHeaders,
+			body: this.serializeBody(body, composedHeaders.get("content-type")),
+			signal,
+		});
+
+		if (!response.ok) {
+			const errorBody = await safeReadResponse(response.clone());
+			throw new AnthropicHttpError(
+				response.status,
+				response.statusText,
+				errorBody,
+				new Headers(response.headers),
+			);
+		}
+
+		return response;
+	}
+
+	async parseResponse<T = unknown>(response: Response): Promise<T> {
+		return (await safeReadResponse(response)) as T;
+	}
+
+	private composeUrl(path: string, query?: Record<string, unknown>): string {
+		const normalizedBase = this.baseUrl.endsWith("/")
+			? this.baseUrl
+			: `${this.baseUrl}/`;
+		const url = new URL(path, normalizedBase);
+
+		if (query && Object.keys(query).length > 0) {
+			const params = new URLSearchParams();
+			for (const [key, value] of Object.entries(query)) {
+				if (value === undefined || value === null) {
+					continue;
+				}
+
+				if (Array.isArray(value)) {
+					for (const item of value) {
+						params.append(key, String(item));
+					}
+				} else {
+					params.append(key, String(value));
+				}
+			}
+
+			url.search = params.toString();
+		}
+
+		return url.toString();
+	}
+
+	private composeHeaders(
+		headers: Record<string, string> = {},
+		body?: unknown,
+	): Headers {
+		const composed = new Headers({
+			...this.defaultHeaders,
+			...headers,
+		});
+
+		composed.set("x-api-key", this.apiKey);
+		composed.set("anthropic-version", this.version);
+		if (this.beta) {
+			composed.set("anthropic-beta", this.beta);
+		}
+
+		if (
+			body !== undefined &&
+			!(body instanceof FormData) &&
+			!(body instanceof ArrayBuffer) &&
+			!(body instanceof Blob) &&
+			!(body instanceof URLSearchParams) &&
+			!composed.has("content-type")
+		) {
+			composed.set("content-type", JSON_CONTENT_TYPE);
+		}
+
+		return composed;
+	}
+
+	private serializeBody(
+		body: unknown,
+		contentType: string | null | undefined,
+	): BodyInit | undefined {
+		if (body === undefined || body === null) {
+			return undefined;
+		}
+
+		if (
+			body instanceof FormData ||
+			body instanceof Blob ||
+			body instanceof ArrayBuffer ||
+			body instanceof URLSearchParams ||
+			typeof body === "string"
+		) {
+			return body as BodyInit;
+		}
+
+		if (
+			contentType?.includes("application/x-www-form-urlencoded") &&
+			isPlainObject(body)
+		) {
+			const params = new URLSearchParams();
+			for (const [key, value] of Object.entries(body)) {
+				if (value === undefined || value === null) {
+					continue;
+				}
+				params.append(key, String(value));
+			}
+
+			return params;
+		}
+
+		if (contentType?.includes("application/json") || !contentType) {
+			return JSON.stringify(body);
+		}
+
+		return body as BodyInit;
+	}
+}
+
+async function safeReadResponse(response: Response): Promise<unknown> {
+	const contentType = response.headers.get("content-type");
+
+	if (!contentType) {
+		return undefined;
+	}
+
+	if (contentType.includes("application/json")) {
+		return response.json();
+	}
+
+	if (contentType.includes("text/")) {
+		return response.text();
+	}
+
+	return response.arrayBuffer();
+}
+
+export class AnthropicHttpError extends Error {
+	readonly status: number;
+	readonly statusText: string;
+	readonly body: unknown;
+	readonly headers: Headers;
+
+	constructor(
+		status: number,
+		statusText: string,
+		body: unknown,
+		headers: Headers = new Headers(),
+	) {
+		super(`Anthropic request failed with status ${status} ${statusText}`);
+		this.status = status;
+		this.statusText = statusText;
+		this.body = body;
+		this.headers = headers;
+	}
+}

--- a/app/api/anthropic/modules/module-factory.ts
+++ b/app/api/anthropic/modules/module-factory.ts
@@ -1,0 +1,59 @@
+import type {
+	OperationDefinition,
+	OperationRegistry,
+} from "./operation-registry";
+import type { AnthropicSDKClient } from "../sdk/anthropic-sdk-client";
+
+export type OperationInvoker = (
+	options?: import("../sdk/anthropic-sdk-client").OperationCallOptions,
+) => Promise<unknown>;
+
+export type OperationModule = Record<string, OperationInvoker> & {
+	readonly tag: string;
+	readonly operations: readonly OperationDefinition[];
+};
+
+export function buildOperationModules(
+	registry: OperationRegistry,
+	client: AnthropicSDKClient,
+): Record<string, OperationModule> {
+	const modules: Record<string, OperationModule> = {};
+
+	for (const [tag, operations] of registry.byTag.entries()) {
+		const invokers: Record<string, OperationInvoker> = {};
+
+		for (const operation of operations) {
+			invokers[operation.id] = (options) => client.call(operation.id, options);
+		}
+
+		const normalizedKey = normalizeTag(tag);
+
+		modules[normalizedKey] = Object.assign(invokers, {
+			operations,
+			tag,
+		});
+	}
+
+	return modules;
+}
+
+function normalizeTag(tag: string): string {
+	const sanitized = tag.trim().toLowerCase();
+
+	if (sanitized.length === 0) {
+		return "untitled";
+	}
+
+	const firstToken = sanitized.split(/\s+/)[0] ?? sanitized;
+	const cleaned = firstToken.replace(/[^a-z0-9]/g, "");
+
+	if (cleaned.length === 0) {
+		return "untitled";
+	}
+
+	if (/^\d/.test(cleaned)) {
+		return `_${cleaned}`;
+	}
+
+	return cleaned;
+}

--- a/app/api/anthropic/modules/operation-registry.ts
+++ b/app/api/anthropic/modules/operation-registry.ts
@@ -1,0 +1,145 @@
+export type HttpMethod =
+	| "get"
+	| "put"
+	| "post"
+	| "delete"
+	| "options"
+	| "head"
+	| "patch"
+	| "trace";
+
+export interface OperationParameter {
+	readonly in: "path" | "query" | "header";
+	readonly name: string;
+	readonly required?: boolean;
+}
+
+export interface OperationDefinition {
+	readonly id: string;
+	readonly method: HttpMethod;
+	readonly path: string;
+	readonly tag: string;
+	readonly summary: string;
+	readonly parameters: readonly OperationParameter[];
+}
+
+export interface OperationRegistry {
+	readonly byId: Map<string, OperationDefinition>;
+	readonly byTag: Map<string, readonly OperationDefinition[]>;
+	readonly matchers: readonly OperationMatcher[];
+}
+
+export interface MatchedOperation {
+	readonly operation: OperationDefinition;
+	readonly pathParams: Record<string, string>;
+}
+
+interface OperationMatcher {
+	readonly definition: OperationDefinition;
+	readonly segments: readonly PathSegment[];
+}
+
+type PathSegment =
+	| { readonly type: "literal"; readonly value: string }
+	| { readonly type: "parameter"; readonly name: string };
+
+export function buildOperationRegistry(
+	operations: readonly OperationDefinition[],
+): OperationRegistry {
+	const byId = new Map<string, OperationDefinition>();
+	const byTag = new Map<string, OperationDefinition[]>();
+	const matchers: OperationMatcher[] = [];
+
+	for (const operation of operations) {
+		byId.set(operation.id, operation);
+		matchers.push(createMatcher(operation));
+
+		const existing = byTag.get(operation.tag) ?? [];
+		byTag.set(operation.tag, [...existing, operation]);
+	}
+
+	return {
+		byId,
+		byTag: new Map([...byTag.entries()].map(([tag, defs]) => [tag, [...defs]])),
+		matchers,
+	};
+}
+
+export function matchOperationByPath(
+	registry: OperationRegistry,
+	method: HttpMethod,
+	path: string,
+): MatchedOperation | undefined {
+	const normalized = normalizePath(path);
+	const targetSegments = normalized === "" ? [] : normalized.split("/");
+
+	for (const matcher of registry.matchers) {
+		if (matcher.definition.method !== method) {
+			continue;
+		}
+
+		if (matcher.segments.length !== targetSegments.length) {
+			continue;
+		}
+
+		const pathParams: Record<string, string> = {};
+		let matched = true;
+
+		for (let index = 0; index < matcher.segments.length; index += 1) {
+			const segment = matcher.segments[index];
+			const candidate = targetSegments[index];
+
+			if (segment.type === "literal") {
+				if (segment.value !== candidate) {
+					matched = false;
+					break;
+				}
+
+				continue;
+			}
+
+			try {
+				pathParams[segment.name] = decodeURIComponent(candidate);
+			} catch {
+				pathParams[segment.name] = candidate;
+			}
+		}
+
+		if (matched) {
+			return { operation: matcher.definition, pathParams };
+		}
+	}
+
+	return undefined;
+}
+
+function createMatcher(definition: OperationDefinition): OperationMatcher {
+	const segments = splitPath(definition.path).map<PathSegment>((segment) => {
+		const parameterMatch = segment.match(/^\{(.+?)\}$/);
+
+		if (parameterMatch) {
+			return { type: "parameter", name: parameterMatch[1] };
+		}
+
+		return { type: "literal", value: segment };
+	});
+
+	return {
+		definition,
+		segments,
+	};
+}
+
+function splitPath(path: string): string[] {
+	const trimmed = normalizePath(path);
+
+	if (trimmed === "") {
+		return [];
+	}
+
+	return trimmed.split("/");
+}
+
+function normalizePath(path: string): string {
+	return path.replace(/^\/+/, "").replace(/\/+$/, "");
+}

--- a/app/api/anthropic/modules/operations.ts
+++ b/app/api/anthropic/modules/operations.ts
@@ -1,0 +1,81 @@
+import type { OperationDefinition } from "./operation-registry";
+
+export const DEFAULT_OPERATIONS: readonly OperationDefinition[] = [
+	{
+		id: "createMessage",
+		method: "post",
+		path: "messages",
+		tag: "Messages",
+		summary:
+			"Create a Claude message with optional tool use and multimodal content.",
+		parameters: [{ in: "query", name: "stream" }],
+	},
+	{
+		id: "streamMessage",
+		method: "post",
+		path: "messages",
+		tag: "Messages",
+		summary: "Stream a Claude message using server-sent events.",
+		parameters: [{ in: "query", name: "stream" }],
+	},
+	{
+		id: "countMessageTokens",
+		method: "post",
+		path: "messages/count-tokens",
+		tag: "Messages",
+		summary: "Estimate Claude token usage for a prospective message payload.",
+		parameters: [],
+	},
+	{
+		id: "createMessageBatch",
+		method: "post",
+		path: "messages/batches",
+		tag: "MessageBatches",
+		summary: "Create an asynchronous Claude message batch job.",
+		parameters: [],
+	},
+	{
+		id: "listMessageBatches",
+		method: "get",
+		path: "messages/batches",
+		tag: "MessageBatches",
+		summary: "List historical Claude message batches for the account.",
+		parameters: [
+			{ in: "query", name: "limit" },
+			{ in: "query", name: "after" },
+			{ in: "query", name: "before" },
+		],
+	},
+	{
+		id: "retrieveMessageBatch",
+		method: "get",
+		path: "messages/batches/{batchId}",
+		tag: "MessageBatches",
+		summary: "Retrieve metadata for a specific Claude message batch.",
+		parameters: [{ in: "path", name: "batchId", required: true }],
+	},
+	{
+		id: "cancelMessageBatch",
+		method: "post",
+		path: "messages/batches/{batchId}/cancel",
+		tag: "MessageBatches",
+		summary: "Cancel a pending Claude message batch job.",
+		parameters: [{ in: "path", name: "batchId", required: true }],
+	},
+	{
+		id: "listModels",
+		method: "get",
+		path: "models",
+		tag: "Models",
+		summary: "List all available Claude models for the authenticated account.",
+		parameters: [],
+	},
+	{
+		id: "retrieveModel",
+		method: "get",
+		path: "models/{modelId}",
+		tag: "Models",
+		summary: "Retrieve metadata about a specific Claude model.",
+		parameters: [{ in: "path", name: "modelId", required: true }],
+	},
+] as const;

--- a/app/api/anthropic/modules/utils.ts
+++ b/app/api/anthropic/modules/utils.ts
@@ -1,0 +1,60 @@
+export function isPlainObject(
+	value: unknown,
+): value is Record<string, unknown> {
+	return (
+		value !== null &&
+		typeof value === "object" &&
+		(value as Record<string, unknown>).constructor === Object
+	);
+}
+
+export function applyPathParams(
+	path: string,
+	params: Record<string, unknown> = {},
+): string {
+	return path.replace(/\{(.*?)\}/g, (_, key: string) => {
+		if (!(key in params)) {
+			throw new Error(`Missing required path parameter: ${key}`);
+		}
+
+		return encodeURIComponent(String(params[key]));
+	});
+}
+
+export function extractQueryParams(
+	parameters: readonly { in: string; name: string }[],
+	provided: Record<string, unknown> = {},
+): Record<string, unknown> {
+	const result: Record<string, unknown> = {};
+
+	for (const parameter of parameters) {
+		if (parameter.in !== "query") {
+			continue;
+		}
+
+		if (parameter.name in provided) {
+			result[parameter.name] = provided[parameter.name];
+		}
+	}
+
+	return result;
+}
+
+export function extractHeaderParams(
+	parameters: readonly { in: string; name: string }[],
+	provided: Record<string, unknown> = {},
+): Record<string, string> {
+	const result: Record<string, string> = {};
+
+	for (const parameter of parameters) {
+		if (parameter.in !== "header") {
+			continue;
+		}
+
+		if (parameter.name in provided) {
+			result[parameter.name] = String(provided[parameter.name]);
+		}
+	}
+
+	return result;
+}

--- a/app/api/anthropic/sdk/anthropic-sdk-client.ts
+++ b/app/api/anthropic/sdk/anthropic-sdk-client.ts
@@ -1,0 +1,201 @@
+import { buildOperationModules } from "../modules/module-factory";
+import {
+	buildOperationRegistry,
+	matchOperationByPath,
+	type HttpMethod,
+	type MatchedOperation,
+	type OperationDefinition,
+	type OperationRegistry,
+} from "../modules/operation-registry";
+import { DEFAULT_OPERATIONS } from "../modules/operations";
+import {
+	applyPathParams,
+	extractHeaderParams,
+	extractQueryParams,
+} from "../modules/utils";
+import {
+	HttpClient,
+	type RequestOptions,
+	AnthropicHttpError,
+} from "../modules/http-client";
+
+export interface AnthropicSDKClientConfig {
+	readonly apiKey: string;
+	readonly baseUrl?: string;
+	readonly version?: string;
+	readonly beta?: string;
+	readonly defaultHeaders?: Record<string, string>;
+	readonly operations?: readonly OperationDefinition[];
+	readonly requestDefaults?: {
+		readonly headers?: Record<string, string>;
+		readonly query?: Record<string, unknown>;
+	};
+}
+
+export interface OperationCallOptions {
+	readonly pathParams?: Record<string, unknown>;
+	readonly query?: Record<string, unknown>;
+	readonly headers?: Record<string, unknown>;
+	readonly body?: unknown;
+	readonly signal?: AbortSignal;
+}
+
+const DEFAULT_BASE_URL = "https://api.anthropic.com/v1";
+const DEFAULT_VERSION = "2023-06-01";
+
+export class AnthropicSDKClient {
+	private readonly httpClient: HttpClient;
+	private readonly registryPromise: Promise<OperationRegistry>;
+	private modulesCache: Record<
+		string,
+		import("../modules/module-factory").OperationModule
+	> | null = null;
+	private readonly requestDefaults: Required<
+		NonNullable<AnthropicSDKClientConfig["requestDefaults"]>
+	>;
+
+	constructor(config: AnthropicSDKClientConfig) {
+		if (!config.apiKey?.trim()) {
+			throw new Error("AnthropicSDKClient requires an apiKey");
+		}
+
+		const baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
+		const version = config.version ?? DEFAULT_VERSION;
+
+		this.httpClient = new HttpClient({
+			apiKey: config.apiKey,
+			baseUrl,
+			version,
+			beta: config.beta,
+			defaultHeaders: config.defaultHeaders,
+		});
+
+		const operations = config.operations ?? DEFAULT_OPERATIONS;
+		this.registryPromise = Promise.resolve(buildOperationRegistry(operations));
+
+		this.requestDefaults = {
+			headers: config.requestDefaults?.headers ?? {},
+			query: config.requestDefaults?.query ?? {},
+		};
+	}
+
+	async call<T = unknown>(
+		operationId: string,
+		options: OperationCallOptions = {},
+	): Promise<T> {
+		const response = await this.callRaw(operationId, options);
+		return this.httpClient.parseResponse<T>(response);
+	}
+
+	async callRaw(
+		operationId: string,
+		options: OperationCallOptions = {},
+	): Promise<Response> {
+		const operation = await this.getOperationOrThrow(operationId);
+		const requestOptions = this.composeRequestOptions(operation, options);
+		return this.httpClient.requestRaw(requestOptions);
+	}
+
+	async getOperation(
+		operationId: string,
+	): Promise<OperationDefinition | undefined> {
+		const registry = await this.registryPromise;
+		return registry.byId.get(operationId);
+	}
+
+	async resolveOperation(
+		method: HttpMethod,
+		path: string,
+	): Promise<MatchedOperation | undefined> {
+		const registry = await this.registryPromise;
+		return matchOperationByPath(registry, method, path);
+	}
+
+	async modules(): Promise<
+		Record<string, import("../modules/module-factory").OperationModule>
+	> {
+		if (this.modulesCache) {
+			return this.modulesCache;
+		}
+
+		const registry = await this.registryPromise;
+		this.modulesCache = buildOperationModules(registry, this);
+		return this.modulesCache;
+	}
+
+	private async getOperationOrThrow(
+		operationId: string,
+	): Promise<OperationDefinition> {
+		const registry = await this.registryPromise;
+		const operation = registry.byId.get(operationId);
+
+		if (!operation) {
+			throw new Error(`Unknown Anthropic operation: ${operationId}`);
+		}
+
+		return operation;
+	}
+
+	private composeRequestOptions(
+		operation: OperationDefinition,
+		options: OperationCallOptions,
+	): RequestOptions {
+		const path = applyPathParams(operation.path, options.pathParams ?? {});
+
+		const query: Record<string, unknown> = {};
+		mergeDefined(query, this.requestDefaults.query);
+		mergeDefined(
+			query,
+			extractQueryParams(operation.parameters, options.query ?? {}),
+		);
+		mergeDefined(query, options.query ?? {});
+
+		const headers: Record<string, string> = {};
+		mergeDefined(headers, this.requestDefaults.headers);
+		mergeDefined(
+			headers,
+			extractHeaderParams(operation.parameters, options.headers ?? {}),
+		);
+		mergeDefined(headers, stringifyHeaderValues(options.headers ?? {}));
+
+		return {
+			method: operation.method,
+			path,
+			query,
+			headers,
+			body: options.body,
+			signal: options.signal,
+		} satisfies RequestOptions;
+	}
+}
+
+export { AnthropicHttpError };
+
+function mergeDefined<T extends Record<string, unknown>>(
+	target: Record<string, unknown>,
+	source: T,
+): void {
+	for (const [key, value] of Object.entries(source)) {
+		if (value === undefined) {
+			continue;
+		}
+
+		target[key] = value;
+	}
+}
+
+function stringifyHeaderValues(
+	headers: Record<string, unknown>,
+): Record<string, string> {
+	const result: Record<string, string> = {};
+
+	for (const [key, value] of Object.entries(headers)) {
+		if (value === undefined || value === null) {
+			continue;
+		}
+
+		result[key] = String(value);
+	}
+
+	return result;
+}

--- a/app/api/anthropic/sdk/index.ts
+++ b/app/api/anthropic/sdk/index.ts
@@ -1,0 +1,6 @@
+export {
+	AnthropicSDKClient,
+	type AnthropicSDKClientConfig,
+	type OperationCallOptions,
+	AnthropicHttpError,
+} from "./anthropic-sdk-client";


### PR DESCRIPTION
## Summary
- add modular Anthropic operation registry, HTTP client, and SDK wrapper
- document core messages, batch, and model endpoints in the default operation set
- cover the SDK with Vitest to verify module grouping, request composition, and error handling

## Testing
- pnpm vitest run app/api/anthropic/modules/__tests__/registry.test.ts --environment node
- pnpm vitest run app/api/anthropic/_tests/anthropic-client.test.ts --environment node

------
https://chatgpt.com/codex/tasks/task_e_68e5d7df45588329b01a3a40ca156501