### PR TITLE
feat: collapse chat demo components

### DIFF
--- a/components/AvatarSession/Chat.tsx
+++ b/components/AvatarSession/Chat.tsx
@@ -111,7 +111,7 @@ export const Chat: React.FC<ChatProps> = ({
 	);
 
 	// Always append demo content
-	const augmentedMessages = useMemo(
+	const { chatMessages, exampleMessages } = useMemo(
 		() => buildAugmentedMessages(dedupedMessages),
 		[dedupedMessages],
 	);
@@ -122,7 +122,7 @@ export const Chat: React.FC<ChatProps> = ({
 	// Scroll container ref + anchored state (depends on content changes)
 	const { isAtBottom, handleScroll } = useScrollAnchored(scrollRef, {
 		inputOnly,
-		depsForContentChange: [augmentedMessages],
+		depsForContentChange: [chatMessages, exampleMessages],
 	});
 
 	// Allow enabling Markdown header in chat bubbles via env flag for debugging/UX preference
@@ -239,7 +239,8 @@ export const Chat: React.FC<ChatProps> = ({
 				>
 					<ChatContainerContent>
 						<MessageList
-							messages={augmentedMessages}
+							messages={chatMessages}
+							exampleMessages={exampleMessages}
 							isAvatarTalking={isAvatarTalking}
 							lastCopiedId={lastCopiedId}
 							voteState={voteState}

--- a/components/AvatarSession/chat/MessageList.tsx
+++ b/components/AvatarSession/chat/MessageList.tsx
@@ -2,14 +2,23 @@
 
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
+import { ChevronDown } from "lucide-react";
 import { MessageItem } from "../MessageItem";
 import { exampleReasoning } from "./_mock_data/example-reasoning";
 import { type Message as MessageType, MessageSender } from "@/lib/types";
 import { Message, MessageAvatar } from "@/components/ui/message";
 import { Loader } from "@/components/ui/loader";
+import { Button } from "@/components/ui/button";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
 
 interface MessageListProps {
 	messages: MessageType[];
+	exampleMessages?: MessageType[];
 	isAvatarTalking: boolean;
 	lastCopiedId: string | null;
 	voteState: Record<string, "up" | "down" | null>;
@@ -65,6 +74,7 @@ function LazyMessageItem({ children, observeRootMargin = "0px" }: LazyProps) {
 
 export const MessageList: React.FC<MessageListProps> = ({
 	messages,
+	exampleMessages = [],
 	isAvatarTalking,
 	lastCopiedId,
 	voteState,
@@ -76,6 +86,9 @@ export const MessageList: React.FC<MessageListProps> = ({
 	onCompare,
 	showMarkdownHeaderInBubbles,
 }: MessageListProps) => {
+	const [examplesOpen, setExamplesOpen] = useState(false);
+	const hasExamples = exampleMessages.length > 0;
+
 	return (
 		<>
 			{messages.map((message) => (
@@ -110,6 +123,72 @@ export const MessageList: React.FC<MessageListProps> = ({
 					/>
 				</LazyMessageItem>
 			))}
+			{hasExamples && (
+				<div className="mt-6 w-full">
+					<Collapsible
+						open={examplesOpen}
+						onOpenChange={setExamplesOpen}
+						className="w-full"
+					>
+						<div className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-2">
+							<div className="flex flex-col gap-1">
+								<p className="text-sm font-medium text-foreground">
+									Example custom components
+								</p>
+								<p className="text-xs text-muted-foreground">
+									Toggle demo responses showcasing interactive UI elements.
+								</p>
+							</div>
+							<CollapsibleTrigger asChild>
+								<Button variant="ghost" size="sm" className="gap-1 text-xs">
+									{examplesOpen ? "Hide" : "Show"}
+									<ChevronDown
+										className={cn(
+											"h-4 w-4 transition-transform",
+											examplesOpen ? "rotate-180" : "rotate-0",
+										)}
+									/>
+								</Button>
+							</CollapsibleTrigger>
+						</div>
+						<CollapsibleContent className="mt-4 space-y-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:slide-in-from-top-1/2 data-[state=closed]:slide-out-to-top-1/2">
+							{exampleMessages.map((message) => (
+								<LazyMessageItem
+									key={`example-${message.id}`}
+									observeRootMargin="200px"
+								>
+									<MessageItem
+										handleCopy={handleCopy}
+										handleEditToInput={handleEditToInput}
+										onBranch={onBranch}
+										onRetry={(mid) => onRetry(mid)}
+										onCompare={(content, mid) => onCompare(content, mid)}
+										isStreaming={false}
+										lastCopiedId={lastCopiedId}
+										message={message}
+										avatarMarkdownShowHeader={showMarkdownHeaderInBubbles}
+										reasoning={
+											message.id === exampleReasoning.message.id
+												? exampleReasoning.reasoning
+												: undefined
+										}
+										reasoningMarkdown={
+											message.id === exampleReasoning.message.id
+												? exampleReasoning.reasoningMarkdown
+												: undefined
+										}
+										reasoningOpen={message.id === exampleReasoning.message.id}
+										setVote={setVote}
+										streamMode="typewriter"
+										streamSpeed={28}
+										voteState={voteState}
+									/>
+								</LazyMessageItem>
+							))}
+						</CollapsibleContent>
+					</Collapsible>
+				</div>
+			)}
 			{isAvatarTalking && (
 				<Message className="flex gap-2 items-start">
 					<MessageAvatar alt="Avatar" fallback="A" src="/heygen-logo.png" />

--- a/components/AvatarSession/chat/utils/message.tsx
+++ b/components/AvatarSession/chat/utils/message.tsx
@@ -7,6 +7,11 @@ import { exampleSource } from "../_mock_data/example-source";
 import { exampleJsxPreview } from "../_mock_data/example-jsx-preview";
 import { exampleMermaid } from "../_mock_data/example-mermaid";
 
+export interface AugmentedMessages {
+	chatMessages: MessageType[];
+	exampleMessages: MessageType[];
+}
+
 export function buildBaseMessagesIfEmpty(
 	messages: MessageType[],
 ): MessageType[] {
@@ -38,7 +43,9 @@ export function dedupeAdjacent(messages: MessageType[]): MessageType[] {
 	return out;
 }
 
-export function buildAugmentedMessages(deduped: MessageType[]): MessageType[] {
+export function buildAugmentedMessages(
+	deduped: MessageType[],
+): AugmentedMessages {
 	const showExtras =
 		(globalThis as any)?.process?.env?.NEXT_PUBLIC_SHOW_EXTRA_DEMOS === "true";
 	const contentMd = String.raw`# \`CodeBlock\` Component
@@ -242,8 +249,7 @@ npm install shiki
 		jsx: '<div class="flex items-center gap-2"><StatBadge label="Accuracy" value="98%" /><StatBadge label="Score" value="A" hint="model" /></div>',
 	};
 
-	const result: MessageType[] = [
-		...deduped,
+	const exampleMessages: MessageType[] = [
 		exampleReasoning.message,
 		exampleTools.message,
 		exampleMultiCode.message,
@@ -252,6 +258,10 @@ npm install shiki
 		exampleJsxPreview.message,
 		exampleMermaid.message,
 	];
-	if (showExtras) result.push(mockMarkdownOnly, mockCodeOnly, mockJsxOnly);
-	return result;
+	if (showExtras)
+		exampleMessages.push(mockMarkdownOnly, mockCodeOnly, mockJsxOnly);
+	return {
+		chatMessages: deduped,
+		exampleMessages,
+	};
 }


### PR DESCRIPTION
## Summary
- keep core chat history separate from bundled demo messages in the avatar session
- add an "Example custom components" collapsible so the sample UI renders on demand instead of in the main thread

## Testing
- pnpm lint *(fails: repository contains pre-existing lint violations outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5dfa46a30832983a4c5c59b04d6d1