### PR TITLE
feat: expand autoform gallery with typeform showcase

### DIFF
--- a/app/examples/autoform/page.tsx
+++ b/app/examples/autoform/page.tsx
@@ -1,12 +1,66 @@
 "use client";
 
-import ExampleForm from "@/components/external/zod-react-form-auto/examples/ExampleForm";
+import { OnboardingExample } from "@/components/examples/autoform/OnboardingExample";
+import { ProfileComparison } from "@/components/examples/autoform/ProfileComparison";
+import { TypeformShowcase } from "@/components/examples/autoform/TypeformShowcase";
 
 export default function AutoformExamplePage() {
 	return (
-		<div className="p-6">
-			<h1 className="mb-4 text-2xl font-bold">AutoForm Example</h1>
-			<ExampleForm />
+		<div className="container mx-auto space-y-10 p-6">
+			<header className="space-y-2">
+				<h1 className="text-3xl font-semibold tracking-tight">
+					AutoForm Example Gallery
+				</h1>
+				<p className="max-w-3xl text-muted-foreground">
+					Explore how AutoForm renders complex Zod schemas out-of-the-box, how
+					the new Typeform widgets extend those capabilities, and how the
+					generated experience compares to a hand-crafted React Hook Form
+					implementation.
+				</p>
+			</header>
+
+			<section className="space-y-4">
+				<div className="space-y-1">
+					<h2 className="text-2xl font-semibold tracking-tight">
+						Foundational schema rendering
+					</h2>
+					<p className="max-w-2xl text-muted-foreground">
+						The original onboarding demo highlights the baseline AutoForm
+						experience with the core fields you rely on most—email, password,
+						bio, sliders, and calendar inputs—restored in full.
+					</p>
+				</div>
+				<OnboardingExample />
+			</section>
+
+			<section className="space-y-4">
+				<div className="space-y-1">
+					<h2 className="text-2xl font-semibold tracking-tight">
+						Typeform-inspired widgets
+					</h2>
+					<p className="max-w-2xl text-muted-foreground">
+						Powered by the new AutoField renderer registry, this showcase
+						demonstrates contact info blocks, legal consent, rating scales, and
+						other Typeform patterns inferred directly from schema metadata and
+						field configuration.
+					</p>
+				</div>
+				<TypeformShowcase />
+			</section>
+
+			<section className="space-y-4">
+				<div className="space-y-1">
+					<h2 className="text-2xl font-semibold tracking-tight">
+						AutoForm vs. manual wiring
+					</h2>
+					<p className="max-w-2xl text-muted-foreground">
+						Compare the declarative AutoForm output with a manually wired React
+						Hook Form build using the same schema, resolver, and validation
+						rules.
+					</p>
+				</div>
+				<ProfileComparison />
+			</section>
 		</div>
 	);
 }

--- a/components/examples/autoform/OnboardingExample.tsx
+++ b/components/examples/autoform/OnboardingExample.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import * as React from "react";
+import { z } from "zod";
+
+import { AutoForm } from "@/components/forms/AutoForm";
+import { useZodForm } from "@/components/forms/useZodForm";
+import type { FieldsConfig } from "@/components/forms/utils";
+import { ResultPreview } from "./ResultPreview";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+
+const onboardingSchema = z.object({
+	name: z.string().min(2, "Name must contain at least 2 characters"),
+	email: z.string().email("Enter a valid email"),
+	password: z.string().min(8, "Password must be at least 8 characters"),
+	role: z.enum(["design", "engineering", "product", "marketing"], {
+		required_error: "Select a primary role",
+	}),
+	bio: z
+		.string()
+		.min(20, "Tell us a bit more about your work")
+		.max(300, "Bio should stay under 300 characters"),
+	skills: z
+		.array(z.string().min(1))
+		.min(1, "Add at least one core skill")
+		.describe("Comma separated skills"),
+	age: z.number().int().min(18, "Must be at least 18").max(80),
+	birthday: z.string().regex(/\d{4}-\d{2}-\d{2}/, "Use the YYYY-MM-DD format"),
+	marketingOptIn: z.boolean().optional(),
+});
+
+type OnboardingValues = z.infer<typeof onboardingSchema>;
+
+const onboardingDefaults: OnboardingValues = {
+	name: "Alex Johnson",
+	email: "alex@example.com",
+	password: "hunter422",
+	role: "product",
+	bio: "Product leader exploring AutoForm-powered onboarding flows for faster prototyping.",
+	skills: ["React", "TypeScript", "UX"],
+	age: 32,
+	birthday: "1993-06-15",
+	marketingOptIn: true,
+};
+
+const onboardingFields: FieldsConfig<OnboardingValues> = {
+	name: { label: "Full name", placeholder: "Jane Doe" },
+	email: { label: "Email", placeholder: "name@example.com" },
+	password: { label: "Password", widget: "password" },
+	role: {
+		label: "Primary role",
+		widget: "select",
+		options: [
+			{ value: "design", label: "Design" },
+			{ value: "engineering", label: "Engineering" },
+			{ value: "product", label: "Product" },
+			{ value: "marketing", label: "Marketing" },
+		],
+	},
+	bio: {
+		label: "Professional bio",
+		widget: "textarea",
+		rows: 5,
+		placeholder: "Share a short summary of your background",
+	},
+	skills: {
+		label: "Key skills",
+		placeholder: "Add a skill and press Enter",
+	},
+	age: {
+		label: "Age",
+		widget: "slider",
+		min: 18,
+		max: 80,
+		step: 1,
+	},
+	birthday: {
+		label: "Birthday",
+		placeholder: "YYYY-MM-DD",
+	},
+	marketingOptIn: {
+		label: "Send me product updates",
+	},
+};
+
+export function OnboardingExample() {
+	const [submitted, setSubmitted] = React.useState<OnboardingValues | null>(
+		null,
+	);
+	const form = useZodForm(onboardingSchema, {
+		defaultValues: onboardingDefaults,
+	});
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Foundational AutoForm</CardTitle>
+				<CardDescription>
+					Generated directly from the onboarding schema with zero manual layout
+					code.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<AutoForm
+					fields={onboardingFields}
+					form={form}
+					onSubmit={async (values) => {
+						setSubmitted(values);
+					}}
+					schema={onboardingSchema}
+					submitLabel="Save profile"
+				/>
+				<ResultPreview title="Submission" values={submitted} />
+			</CardContent>
+		</Card>
+	);
+}

--- a/components/examples/autoform/ProfileComparison.tsx
+++ b/components/examples/autoform/ProfileComparison.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import * as React from "react";
+import { Controller } from "react-hook-form";
+import { z } from "zod";
+
+import { AutoForm } from "@/components/forms/AutoForm";
+import { useZodForm } from "@/components/forms/useZodForm";
+import type { FieldsConfig } from "@/components/forms/utils";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Slider } from "@/components/ui/slider";
+import { Textarea } from "@/components/ui/textarea";
+
+import { ResultPreview } from "./ResultPreview";
+
+const profileSchema = z.object({
+	email: z.string().email("Please provide a valid email"),
+	password: z.string().min(8, "Password must be at least 8 characters"),
+	bio: z
+		.string()
+		.min(10, "Tell us a little more about yourself")
+		.max(200, "Bio should be 200 characters or less"),
+	age: z.number().int().min(18).max(80),
+	birthday: z.string().regex(/\d{4}-\d{2}-\d{2}/, "Use the YYYY-MM-DD format"),
+});
+
+type ProfileSchema = typeof profileSchema;
+type ProfileValues = z.infer<ProfileSchema>;
+
+const profileDefaults: ProfileValues = {
+	email: "name@example.com",
+	password: "hunter422",
+	bio: "I love exploring new UI patterns with AutoForm.",
+	age: 30,
+	birthday: "1995-01-01",
+};
+const autoFields: FieldsConfig<ProfileValues> = {
+	email: { label: "Email", placeholder: "name@example.com" },
+	password: { label: "Password", widget: "password" },
+	bio: {
+		label: "Bio",
+		widget: "textarea",
+		rows: 4,
+		placeholder: "Tell us about yourself",
+	},
+	age: { label: "Age", widget: "slider", min: 18, max: 80, step: 1 },
+	birthday: { label: "Birthday", placeholder: "YYYY-MM-DD" },
+};
+
+function ManualProfileForm({
+	onSubmit,
+	defaultValues,
+}: {
+	onSubmit: (values: ProfileValues) => void;
+	defaultValues: ProfileValues;
+}) {
+	const form = useZodForm(profileSchema, {
+		defaultValues,
+	});
+
+	return (
+		<form className="space-y-3" onSubmit={form.handleSubmit(onSubmit)}>
+			<div className="flex flex-col gap-1">
+				<label className="text-sm text-muted-foreground" htmlFor="manual-email">
+					Email
+				</label>
+				<Input
+					id="manual-email"
+					placeholder="name@example.com"
+					type="email"
+					{...form.register("email")}
+				/>
+				{form.formState.errors.email && (
+					<p className="text-xs text-red-500">
+						{form.formState.errors.email.message}
+					</p>
+				)}
+			</div>
+			<div className="flex flex-col gap-1">
+				<label
+					className="text-sm text-muted-foreground"
+					htmlFor="manual-password"
+				>
+					Password
+				</label>
+				<Input
+					id="manual-password"
+					placeholder="Enter your password"
+					type="password"
+					{...form.register("password")}
+				/>
+				{form.formState.errors.password && (
+					<p className="text-xs text-red-500">
+						{form.formState.errors.password.message}
+					</p>
+				)}
+			</div>
+			<div className="flex flex-col gap-1">
+				<label className="text-sm text-muted-foreground" htmlFor="manual-bio">
+					Bio
+				</label>
+				<Textarea
+					id="manual-bio"
+					placeholder="Tell us about yourself"
+					rows={4}
+					{...form.register("bio")}
+				/>
+				{form.formState.errors.bio && (
+					<p className="text-xs text-red-500">
+						{form.formState.errors.bio.message}
+					</p>
+				)}
+			</div>
+			<Controller
+				control={form.control}
+				name="age"
+				render={({ field }) => (
+					<div className="flex flex-col gap-1">
+						<label className="text-sm text-muted-foreground">
+							Age
+							<span className="ml-1 text-xs text-muted-foreground">
+								(
+								{typeof field.value === "number"
+									? field.value
+									: defaultValues.age}
+								)
+							</span>
+						</label>
+						<Slider
+							max={80}
+							min={18}
+							step={1}
+							value={[
+								typeof field.value === "number"
+									? field.value
+									: defaultValues.age,
+							]}
+							onValueChange={(val) => field.onChange(val[0])}
+						/>
+						{form.formState.errors.age && (
+							<p className="text-xs text-red-500">
+								{form.formState.errors.age.message}
+							</p>
+						)}
+					</div>
+				)}
+			/>
+			<div className="flex flex-col gap-1">
+				<label
+					className="text-sm text-muted-foreground"
+					htmlFor="manual-birthday"
+				>
+					Birthday
+				</label>
+				<Input
+					id="manual-birthday"
+					type="date"
+					{...form.register("birthday")}
+				/>
+				{form.formState.errors.birthday && (
+					<p className="text-xs text-red-500">
+						{form.formState.errors.birthday.message}
+					</p>
+				)}
+			</div>
+			<Button
+				className="w-full"
+				disabled={!form.formState.isValid}
+				type="submit"
+			>
+				Save profile
+			</Button>
+		</form>
+	);
+}
+
+export function ProfileComparison() {
+	const [autoResult, setAutoResult] = React.useState<ProfileValues | null>(
+		null,
+	);
+	const [manualResult, setManualResult] = React.useState<ProfileValues | null>(
+		null,
+	);
+
+	const autoForm = useZodForm(profileSchema, {
+		defaultValues: profileDefaults,
+	});
+
+	return (
+		<div className="grid gap-6 md:grid-cols-2">
+			<Card>
+				<CardHeader>
+					<CardTitle>AutoForm (AutoField)</CardTitle>
+					<CardDescription>
+						Schema-driven rendering with zero manual layout code.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<AutoForm
+						fields={autoFields}
+						form={autoForm}
+						onSubmit={(values) => setAutoResult(values)}
+						schema={profileSchema}
+						submitLabel="Save profile"
+					/>
+					<ResultPreview title="AutoForm submission" values={autoResult} />
+				</CardContent>
+			</Card>
+			<Card>
+				<CardHeader>
+					<CardTitle>Manual Fields (Reference)</CardTitle>
+					<CardDescription>
+						Hand-authored inputs wired to the same schema and resolver.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<ManualProfileForm
+						defaultValues={profileDefaults}
+						onSubmit={(values) => setManualResult(values)}
+					/>
+					<ResultPreview title="Manual submission" values={manualResult} />
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/components/examples/autoform/ResultPreview.tsx
+++ b/components/examples/autoform/ResultPreview.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import * as React from "react";
+
+type ResultPreviewProps<T> = {
+	values: T | null;
+	title?: string;
+};
+
+export function ResultPreview<T>({ values, title }: ResultPreviewProps<T>) {
+	if (!values) return null;
+
+	return (
+		<div className="mt-4 space-y-2">
+			{title ? (
+				<div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+					{title}
+				</div>
+			) : null}
+			<pre className="max-h-56 overflow-auto rounded-md bg-muted/60 p-3 text-xs">
+				{JSON.stringify(values, null, 2)}
+			</pre>
+		</div>
+	);
+}

--- a/components/examples/autoform/TypeformShowcase.tsx
+++ b/components/examples/autoform/TypeformShowcase.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import * as React from "react";
+import { z } from "zod";
+
+import {
+	AutoForm as TypeformAutoForm,
+	useZodForm as useTypeformZodForm,
+} from "@/packages/autoform/src";
+import type { FieldsConfig } from "@/packages/autoform/src";
+import { ResultPreview } from "./ResultPreview";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+
+const engagementSchema = z.object({
+	contact: z
+		.object({
+			firstName: z.string().min(1, "Required"),
+			lastName: z.string().min(1, "Required"),
+			email: z.string().email("Enter a valid email"),
+			phone: z.string().min(7, "Include a phone number"),
+			address: z.object({
+				line1: z.string().min(1, "Required"),
+				line2: z.string().optional(),
+				city: z.string().min(1, "Required"),
+				state: z.string().optional(),
+				postalCode: z.string().min(2, "Required"),
+				country: z.string().min(2, "Required"),
+			}),
+		})
+		.describe("typeform:contact-info"),
+	website: z.string().url("Enter a valid URL").describe("typeform:website"),
+	productFocus: z.enum([
+		"lead-generation",
+		"support",
+		"research",
+		"operations",
+	]),
+	evaluationThemes: z
+		.array(z.string())
+		.min(1, "Select at least one theme")
+		.describe("Multiple choice evaluation areas"),
+	satisfaction: z
+		.number()
+		.min(0)
+		.max(10)
+		.describe("nps: Likelihood to recommend AutoForm"),
+	fitRating: z.number().min(1).max(5).describe("typeform:rating"),
+	launchDate: z
+		.string()
+		.regex(/\d{4}-\d{2}-\d{2}/, "Use YYYY-MM-DD")
+		.describe("typeform:date"),
+	consent: z.boolean().describe("legal"),
+	summary: z
+		.string()
+		.min(30, "Share a short summary")
+		.describe("Long text overview"),
+});
+
+type EngagementValues = z.infer<typeof engagementSchema>;
+
+const engagementDefaults: EngagementValues = {
+	contact: {
+		firstName: "Jamie",
+		lastName: "Rivera",
+		email: "jamie@example.com",
+		phone: "+1 415 555 0198",
+		address: {
+			line1: "500 Howard St",
+			line2: "Suite 300",
+			city: "San Francisco",
+			state: "CA",
+			postalCode: "94105",
+			country: "US",
+		},
+	},
+	website: "https://example-product.io",
+	productFocus: "lead-generation",
+	evaluationThemes: ["dynamic-content", "workflow-automation"],
+	satisfaction: 8,
+	fitRating: 4,
+	launchDate: "2025-03-15",
+	consent: true,
+	summary:
+		"We are evaluating AutoForm to accelerate personalized lead capture for upcoming campaigns.",
+};
+
+const engagementFields: FieldsConfig<EngagementValues> = {
+	contact: {
+		label: "Contact info",
+		questionType: "contactInfo",
+		questionSettings: {
+			contactFields: ["firstName", "lastName", "email", "phone", "address"],
+			fieldLabels: {
+				firstName: "First name",
+				lastName: "Last name",
+				phone: "Phone number",
+				address: "Mailing address",
+			},
+		},
+	},
+	website: {
+		label: "Company website",
+		questionType: "website",
+		placeholder: "https://",
+	},
+	productFocus: {
+		label: "Primary use case",
+		widget: "select",
+		questionType: "dropdown",
+		options: [
+			{ value: "lead-generation", label: "Lead generation" },
+			{ value: "support", label: "Support automation" },
+			{ value: "research", label: "Customer research" },
+			{ value: "operations", label: "Operations" },
+		],
+	},
+	evaluationThemes: {
+		label: "Focus areas",
+		multiple: true,
+		questionType: "multipleChoice",
+		options: [
+			{ value: "dynamic-content", label: "Dynamic content" },
+			{ value: "workflow-automation", label: "Workflow automation" },
+			{ value: "analytics", label: "Analytics & reporting" },
+			{ value: "integrations", label: "Integrations" },
+		],
+	},
+	satisfaction: {
+		label: "NPS score",
+		questionType: "nps",
+		questionSettings: {
+			npsLabels: ["Not at all", "Neutral", "Extremely likely"],
+		},
+	},
+	fitRating: {
+		label: "Feature fit",
+		questionType: "rating",
+		questionSettings: {
+			ratingMax: 5,
+			ratingIcon: "star",
+		},
+	},
+	launchDate: {
+		label: "Target launch date",
+		questionType: "date",
+		questionSettings: {
+			captionLayout: "dropdown",
+			fromYear: 2024,
+			toYear: 2027,
+		},
+	},
+	consent: {
+		label: "Marketing consent",
+		questionType: "legal",
+		questionSettings: {
+			legalText: "I agree to receive onboarding resources and product updates.",
+		},
+	},
+	summary: {
+		label: "Project summary",
+		widget: "textarea",
+		rows: 5,
+		questionType: "longText",
+		placeholder: "Share goals, success metrics, or constraints",
+	},
+};
+
+export function TypeformShowcase() {
+	const [submitted, setSubmitted] = React.useState<EngagementValues | null>(
+		null,
+	);
+	const form = useTypeformZodForm(engagementSchema, {
+		defaultValues: engagementDefaults,
+	});
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Typeform widgets showcase</CardTitle>
+				<CardDescription>
+					Highlights the new AutoField renderers for contact info, dropdown,
+					rating, and legal consent blocks.
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				<TypeformAutoForm
+					fields={engagementFields}
+					form={form}
+					onSubmit={async (values) => setSubmitted(values)}
+					schema={engagementSchema}
+					submitLabel="Save engagement"
+				/>
+				<div className="h-px w-full bg-border" />
+				<ResultPreview title="Submission" values={submitted} />
+			</CardContent>
+		</Card>
+	);
+}

--- a/packages/autoform/src/index.ts
+++ b/packages/autoform/src/index.ts
@@ -1,5 +1,9 @@
 export { AutoForm } from "./AutoForm";
 export { AutoField } from "./AutoField";
 export { useZodForm } from "./useZodForm";
-export { unwrapType, type FieldsConfig } from "./utils/utils";
+export { unwrapType, type FieldsConfig, type FieldConfig } from "./utils/utils";
+export {
+	determineQuestionType,
+	type TypeformQuestionType,
+} from "./typeform/types";
 export type { AutoFieldProps } from "./AutoField";

--- a/packages/autoform/src/typeform/__tests__/question-type.test.ts
+++ b/packages/autoform/src/typeform/__tests__/question-type.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { determineQuestionType } from "../types";
+import type { FieldConfig } from "../../utils/utils";
+
+const baseConfig: FieldConfig = {};
+
+describe("determineQuestionType", () => {
+	it("prioritizes an explicit question type from the field config", () => {
+		const schema = z.string();
+		const cfg: FieldConfig = { ...baseConfig, questionType: "legal" };
+
+		expect(determineQuestionType(schema, cfg, "terms")).toBe("legal");
+	});
+
+	it("parses typeform: metadata from schema descriptions", () => {
+		const schema = z.string().describe("typeform:phone-number");
+
+		expect(determineQuestionType(schema, baseConfig, "phone")).toBe(
+			"phoneNumber",
+		);
+	});
+
+	it("infers email questions from Zod email validators", () => {
+		const schema = z.string().email();
+
+		expect(determineQuestionType(schema, baseConfig, "email")).toBe("email");
+	});
+
+	it("treats boolean fields as yes/no questions by default", () => {
+		const schema = z.boolean();
+
+		expect(determineQuestionType(schema, baseConfig, "subscribed")).toBe(
+			"yesNo",
+		);
+	});
+
+	it("detects NPS style number fields from descriptions", () => {
+		const schema = z
+			.number()
+			.min(0)
+			.max(10)
+			.describe("nps: How likely are you to recommend us?");
+
+		expect(determineQuestionType(schema, baseConfig, "npsScore")).toBe("nps");
+	});
+
+	it("falls back to the generic number question for basic numeric fields", () => {
+		const schema = z.number();
+
+		expect(determineQuestionType(schema, baseConfig, "quantity")).toBe(
+			"number",
+		);
+	});
+});

--- a/packages/autoform/src/typeform/renderers/choice-advanced.tsx
+++ b/packages/autoform/src/typeform/renderers/choice-advanced.tsx
@@ -1,0 +1,167 @@
+import React from "react";
+
+import {
+	FieldError,
+	FieldLabel,
+	TypeformRendererMap,
+	TypeformRendererProps,
+	ensureArray,
+	getOptions,
+} from "./shared";
+
+const renderRanking = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	const options = getOptions(cfg);
+	const value = ensureArray<string>(form.watch(name as any));
+	const ordered = React.useMemo(() => {
+		const missing = options.filter((opt) => !value.includes(opt.value));
+		return [...value, ...missing.map((opt) => opt.value)];
+	}, [options, value]);
+
+	const move = (index: number, delta: number) => {
+		const next = [...ordered];
+		const target = index + delta;
+		if (target < 0 || target >= next.length) return;
+		const [item] = next.splice(index, 1);
+		next.splice(target, 0, item);
+		form.setValue(name as any, next as any, {
+			shouldDirty: true,
+			shouldValidate: true,
+		});
+	};
+
+	return (
+		<div className="flex flex-col gap-2">
+			<FieldLabel description={cfg.description} label={label} />
+			<ul className="space-y-2">
+				{ordered.map((valueKey, index) => {
+					const option = options.find((opt) => opt.value === valueKey) ?? {
+						label: valueKey,
+						value: valueKey,
+					};
+					return (
+						<li
+							key={valueKey}
+							className="flex items-center justify-between rounded-md border border-border bg-background px-3 py-2 text-sm"
+						>
+							<span>
+								<span className="mr-2 text-xs text-muted-foreground">
+									{index + 1}.
+								</span>
+								{option.label}
+							</span>
+							<div className="flex gap-1">
+								<button
+									className="rounded border border-border px-2 py-1 text-xs"
+									onClick={(event) => {
+										event.preventDefault();
+										move(index, -1);
+									}}
+									type="button"
+								>
+									↑
+								</button>
+								<button
+									className="rounded border border-border px-2 py-1 text-xs"
+									onClick={(event) => {
+										event.preventDefault();
+										move(index, 1);
+									}}
+									type="button"
+								>
+									↓
+								</button>
+							</div>
+						</li>
+					);
+				})}
+			</ul>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+const renderMatrix = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	const matrix = cfg.questionSettings?.matrix as
+		| { rows: string[]; columns: string[]; multiSelect?: boolean }
+		| undefined;
+	if (!matrix) return undefined;
+	const value =
+		(form.watch(name as any) as Record<string, string | string[]>) ?? {};
+
+	const handleSelect = (row: string, column: string) => {
+		if (matrix.multiSelect) {
+			const current = ensureArray<string>(value[row]);
+			const next = current.includes(column)
+				? current.filter((c) => c !== column)
+				: [...current, column];
+			form.setValue(name as any, { ...value, [row]: next } as any, {
+				shouldDirty: true,
+				shouldValidate: true,
+			});
+			return;
+		}
+		form.setValue(name as any, { ...value, [row]: column } as any, {
+			shouldDirty: true,
+			shouldValidate: true,
+		});
+	};
+
+	return (
+		<div className="flex flex-col gap-2 overflow-x-auto">
+			<FieldLabel description={cfg.description} label={label} />
+			<table className="min-w-full border border-border text-sm">
+				<thead className="bg-muted/40">
+					<tr>
+						<th className="px-3 py-2 text-left" />
+						{matrix.columns.map((column) => (
+							<th key={column} className="px-3 py-2 text-left font-medium">
+								{column}
+							</th>
+						))}
+					</tr>
+				</thead>
+				<tbody>
+					{matrix.rows.map((row) => {
+						const rowValue = value[row];
+						return (
+							<tr key={row} className="border-t border-border">
+								<th className="px-3 py-2 text-left font-medium">{row}</th>
+								{matrix.columns.map((column) => {
+									const selected = matrix.multiSelect
+										? ensureArray(rowValue).includes(column)
+										: rowValue === column;
+									return (
+										<td key={column} className="px-3 py-2">
+											<button
+												className={`h-8 w-8 rounded-full border transition focus:outline-none focus:ring-2 focus:ring-primary ${
+													selected
+														? "border-primary bg-primary text-primary-foreground"
+														: "border-border"
+												}`}
+												onClick={(event) => {
+													event.preventDefault();
+													handleSelect(row, column);
+												}}
+												type="button"
+											>
+												{selected ? "✓" : ""}
+											</button>
+										</td>
+									);
+								})}
+							</tr>
+						);
+					})}
+				</tbody>
+			</table>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+export const advancedChoiceRenderers: TypeformRendererMap = {
+	ranking: renderRanking,
+	matrix: renderMatrix,
+};

--- a/packages/autoform/src/typeform/renderers/choice-basic.tsx
+++ b/packages/autoform/src/typeform/renderers/choice-basic.tsx
@@ -1,0 +1,230 @@
+import React from "react";
+
+import {
+	FieldError,
+	FieldLabel,
+	TypeformRendererMap,
+	TypeformRendererProps,
+	ensureArray,
+	getOptions,
+} from "./shared";
+
+const renderMultipleChoice = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	const options = getOptions(cfg);
+	const allowMultiple = Boolean(cfg.multiple);
+
+	if (allowMultiple) {
+		const selected = ensureArray(form.watch(name as any));
+		const toggle = (value: string) => {
+			const next = selected.includes(value)
+				? selected.filter((v) => v !== value)
+				: [...selected, value];
+			form.setValue(name as any, next as any, {
+				shouldDirty: true,
+				shouldValidate: true,
+			});
+		};
+
+		return (
+			<div className="flex flex-col gap-2">
+				<FieldLabel description={cfg.description} label={label} />
+				<div className="grid gap-2 sm:grid-cols-2">
+					{options.map((opt) => {
+						const checked = selected.includes(opt.value);
+						return (
+							<button
+								key={opt.value}
+								className={`rounded-md border px-3 py-2 text-left text-sm transition focus:outline-none focus:ring-2 focus:ring-primary ${
+									checked
+										? "border-primary bg-primary/10"
+										: "border-border bg-background"
+								}`}
+								onClick={(event) => {
+									event.preventDefault();
+									toggle(opt.value);
+								}}
+								type="button"
+							>
+								<div className="font-medium">{opt.label}</div>
+								{opt.description ? (
+									<div className="text-xs text-muted-foreground">
+										{opt.description}
+									</div>
+								) : null}
+							</button>
+						);
+					})}
+				</div>
+				<FieldError message={error} />
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-2">
+			<FieldLabel description={cfg.description} label={label} />
+			<div className="space-y-2">
+				{options.map((opt) => (
+					<label key={opt.value} className="flex items-center gap-2 text-sm">
+						<input
+							className="h-4 w-4 accent-primary"
+							type="radio"
+							value={opt.value}
+							{...form.register(name as any)}
+						/>
+						<span>{opt.label}</span>
+					</label>
+				))}
+			</div>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+const renderDropdown = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	const options = getOptions(cfg);
+
+	return (
+		<div className="flex flex-col gap-1">
+			<FieldLabel description={cfg.description} label={label} />
+			<select
+				className="rounded-md border border-border bg-background px-3 py-2 text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+				defaultValue=""
+				{...form.register(name as any)}
+			>
+				<option disabled value="">
+					Select an option
+				</option>
+				{options.map((opt) => (
+					<option key={opt.value} value={opt.value}>
+						{opt.label}
+					</option>
+				))}
+			</select>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+const renderYesNo = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	const current = form.watch(name as any);
+
+	return (
+		<div className="flex flex-col gap-2">
+			<FieldLabel description={cfg.description} label={label} />
+			<div className="flex gap-2">
+				{[true, false].map((value) => {
+					const active = current === value;
+					return (
+						<button
+							key={String(value)}
+							className={`flex-1 rounded-md border px-3 py-2 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-primary ${
+								active
+									? "border-primary bg-primary text-primary-foreground"
+									: "border-border bg-background"
+							}`}
+							onClick={(event) => {
+								event.preventDefault();
+								form.setValue(name as any, value as any, {
+									shouldDirty: true,
+									shouldValidate: true,
+								});
+							}}
+							type="button"
+						>
+							{value ? "Yes" : "No"}
+						</button>
+					);
+				})}
+			</div>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+const renderCheckbox = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	return (
+		<label className="flex items-center gap-3 text-sm text-foreground">
+			<input
+				className="h-4 w-4 accent-primary"
+				type="checkbox"
+				{...form.register(name as any)}
+			/>
+			<span>
+				{label}
+				{cfg.description ? (
+					<span className="ml-2 text-xs text-muted-foreground">
+						{cfg.description}
+					</span>
+				) : null}
+			</span>
+			<FieldError message={error} />
+		</label>
+	);
+};
+
+const renderPictureChoice = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	const options = getOptions(cfg);
+	const current = form.watch(name as any) as string | undefined;
+
+	const choose = (value: string) => {
+		form.setValue(name as any, value as any, {
+			shouldDirty: true,
+			shouldValidate: true,
+		});
+	};
+
+	return (
+		<div className="flex flex-col gap-2">
+			<FieldLabel description={cfg.description} label={label} />
+			<div className="grid gap-3 md:grid-cols-2">
+				{options.map((opt) => {
+					const active = current === opt.value;
+					return (
+						<button
+							key={opt.value}
+							className={`overflow-hidden rounded-lg border text-left shadow-sm transition focus:outline-none focus:ring-2 focus:ring-primary ${
+								active ? "border-primary" : "border-border"
+							}`}
+							onClick={(event) => {
+								event.preventDefault();
+								choose(opt.value);
+							}}
+							type="button"
+						>
+							{opt.imageUrl ? (
+								<img
+									alt={opt.label}
+									className="h-32 w-full object-cover"
+									src={opt.imageUrl}
+								/>
+							) : null}
+							<div className="p-3">
+								<div className="font-medium">{opt.label}</div>
+								{opt.description ? (
+									<div className="text-xs text-muted-foreground">
+										{opt.description}
+									</div>
+								) : null}
+							</div>
+						</button>
+					);
+				})}
+			</div>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+export const basicChoiceRenderers: TypeformRendererMap = {
+	multipleChoice: renderMultipleChoice,
+	dropdown: renderDropdown,
+	yesNo: renderYesNo,
+	checkbox: renderCheckbox,
+	pictureChoice: renderPictureChoice,
+};

--- a/packages/autoform/src/typeform/renderers/contact.tsx
+++ b/packages/autoform/src/typeform/renderers/contact.tsx
@@ -1,0 +1,227 @@
+import React from "react";
+
+import { unwrapType } from "../../utils/utils";
+
+import {
+	FieldError,
+	FieldLabel,
+	TypeformRendererMap,
+	TypeformRendererProps,
+} from "./shared";
+
+const primitiveInputType = (field: string) => {
+	const lower = field.toLowerCase();
+	if (lower.includes("email")) return "email";
+	if (lower.includes("phone")) return "tel";
+	if (lower.includes("website") || lower.includes("url")) return "url";
+	return "text";
+};
+
+const renderTextField = (
+	props: TypeformRendererProps,
+	field: string,
+	label: string,
+	description?: string,
+) => {
+	const { form, name, error, cfg } = props;
+	const fieldName = `${name}.${field}`;
+	const fieldError = (form.formState.errors as any)?.[name]?.[field]?.message as
+		| string
+		| undefined;
+	const fieldLabels =
+		(cfg.questionSettings?.fieldLabels as Record<string, string> | undefined) ??
+		{};
+	const displayLabel = fieldLabels[field] ?? label;
+
+	return (
+		<div key={fieldName} className="flex flex-col gap-1">
+			<FieldLabel description={description} label={displayLabel} />
+			<input
+				className="rounded-md border border-border bg-background px-3 py-2 text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+				type={primitiveInputType(field)}
+				{...form.register(fieldName as any)}
+			/>
+			<FieldError message={fieldError} />
+		</div>
+	);
+};
+
+const renderAddressGrid = (props: TypeformRendererProps) => {
+	const { form, name, cfg } = props;
+	const addressCfg = (cfg.questionSettings?.addressFields as string[]) ?? [];
+	const fields: Array<{ field: string; label: string }> = addressCfg.length
+		? addressCfg.map((key) => ({ field: key, label: key }))
+		: [
+				{ field: "line1", label: "Address line 1" },
+				{ field: "line2", label: "Address line 2" },
+				{ field: "city", label: "City" },
+				{ field: "state", label: "State" },
+				{ field: "postalCode", label: "Postal code" },
+				{ field: "country", label: "Country" },
+			];
+
+	return (
+		<div className="grid gap-2 md:grid-cols-2">
+			{fields.map((field) => {
+				const fieldName = `${name}.${field.field}`;
+				const fieldError = (form.formState.errors as any)?.[name]?.[field.field]
+					?.message as string | undefined;
+
+				return (
+					<div key={fieldName} className="flex flex-col gap-1">
+						<FieldLabel label={field.label} />
+						<input
+							className="rounded-md border border-border bg-background px-3 py-2 text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+							{...form.register(fieldName as any)}
+						/>
+						<FieldError message={fieldError} />
+					</div>
+				);
+			})}
+		</div>
+	);
+};
+
+const renderContactInfo = (props: TypeformRendererProps) => {
+	const { base } = props;
+	const shapeGetter = (base as any)?._def?.shape;
+	const shape: Record<string, any> =
+		typeof shapeGetter === "function"
+			? shapeGetter()
+			: ((base as any)?.shape ?? {});
+	const preferredOrder = (props.cfg.questionSettings?.contactFields as
+		| string[]
+		| undefined) ?? [
+		"firstName",
+		"lastName",
+		"email",
+		"phone",
+		"company",
+		"website",
+		"address",
+	];
+	const remaining = Object.keys(shape).filter(
+		(key) => !preferredOrder.includes(key),
+	);
+	const order = [...preferredOrder, ...remaining];
+
+	return (
+		<div className="flex flex-col gap-2">
+			{order.map((field) => {
+				const def = shape[field];
+				if (!def) return null;
+				const childBase = unwrapType(def);
+				const type =
+					(childBase as any)?._def?.type ?? (childBase as any)?._def?.typeName;
+				if (type === "object" || type === "ZodObject") {
+					return (
+						<div key={field} className="flex flex-col gap-2">
+							<FieldLabel label={field} />
+							{renderAddressGrid({ ...props, name: `${props.name}.${field}` })}
+						</div>
+					);
+				}
+
+				return renderTextField(props, field, field);
+			})}
+		</div>
+	);
+};
+
+const renderPhoneNumber = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	const pattern = (cfg.questionSettings as Record<string, unknown>)
+		?.phonePattern as string | undefined;
+	const placeholder =
+		cfg.placeholder ??
+		(pattern
+			? "Enter phone number"
+			: "Include country code e.g. +1 555 555 5555");
+
+	return (
+		<div className="flex flex-col gap-1">
+			<FieldLabel description={cfg.description} label={label} />
+			<input
+				className="rounded-md border border-border bg-background px-3 py-2 text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+				pattern={pattern}
+				placeholder={placeholder}
+				type="tel"
+				{...form.register(name as any)}
+			/>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+const renderEmail = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	return (
+		<div className="flex flex-col gap-1">
+			<FieldLabel description={cfg.description} label={label} />
+			<input
+				className="rounded-md border border-border bg-background px-3 py-2 text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+				placeholder={cfg.placeholder ?? "name@example.com"}
+				type="email"
+				{...form.register(name as any)}
+			/>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+const renderWebsite = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	return (
+		<div className="flex flex-col gap-1">
+			<FieldLabel description={cfg.description} label={label} />
+			<input
+				className="rounded-md border border-border bg-background px-3 py-2 text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+				placeholder={cfg.placeholder ?? "https://example.com"}
+				type="url"
+				{...form.register(name as any)}
+			/>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+const renderLegal = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	const text =
+		(cfg.questionSettings?.legalText as string | undefined) ??
+		cfg.description ??
+		"I agree to the terms and conditions.";
+	return (
+		<div className="flex flex-col gap-2 rounded-md border border-border bg-muted/20 p-3">
+			<div className="text-sm text-muted-foreground">{text}</div>
+			<label className="flex items-center gap-2 text-sm text-foreground">
+				<input
+					className="h-4 w-4 accent-primary"
+					type="checkbox"
+					{...form.register(name as any)}
+				/>
+				{label}
+			</label>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+const renderAddress = (props: TypeformRendererProps) => {
+	return (
+		<div className="flex flex-col gap-2">
+			<FieldLabel label={props.label} description={props.cfg.description} />
+			{renderAddressGrid(props)}
+			<FieldError message={props.error} />
+		</div>
+	);
+};
+
+export const contactRenderers: TypeformRendererMap = {
+	contactInfo: renderContactInfo,
+	email: renderEmail,
+	phoneNumber: renderPhoneNumber,
+	address: renderAddress,
+	website: renderWebsite,
+	legal: renderLegal,
+};

--- a/packages/autoform/src/typeform/renderers/index.tsx
+++ b/packages/autoform/src/typeform/renderers/index.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import type { TypeformQuestionType } from "../types";
+import type { TypeformRendererProps, TypeformRendererMap } from "./shared";
+import { contactRenderers } from "./contact";
+import { basicChoiceRenderers } from "./choice-basic";
+import { advancedChoiceRenderers } from "./choice-advanced";
+import { scaleRenderers } from "./scale";
+import { textRenderers } from "./text";
+import { otherRenderers } from "./other";
+
+const registry: TypeformRendererMap = {
+	...contactRenderers,
+	...basicChoiceRenderers,
+	...advancedChoiceRenderers,
+	...scaleRenderers,
+	...textRenderers,
+	...otherRenderers,
+};
+
+export const renderTypeformField = (
+	props: TypeformRendererProps & { questionType?: TypeformQuestionType },
+): React.ReactNode | undefined => {
+	if (!props.questionType) return undefined;
+	const renderer = registry[props.questionType];
+	if (!renderer) return undefined;
+	return renderer(props);
+};

--- a/packages/autoform/src/typeform/renderers/other.tsx
+++ b/packages/autoform/src/typeform/renderers/other.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+
+import {
+	FieldError,
+	FieldLabel,
+	TypeformRendererMap,
+	TypeformRendererProps,
+} from "./shared";
+
+const renderNumber = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	return (
+		<div className="flex flex-col gap-1">
+			<FieldLabel description={cfg.description} label={label} />
+			<input
+				className="rounded-md border border-border bg-background px-3 py-2 text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+				min={cfg.min}
+				max={cfg.max}
+				step={cfg.step ?? 1}
+				type="number"
+				{...form.register(name as any, { valueAsNumber: true })}
+			/>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+const renderPayment = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	const settings = cfg.questionSettings?.payment as
+		| { currency?: string; minimum?: number; maximum?: number }
+		| undefined;
+	const currency = settings?.currency ?? "USD";
+
+	return (
+		<div className="flex flex-col gap-2">
+			<FieldLabel description={cfg.description} label={label} />
+			<div className="flex items-center gap-2">
+				<span className="rounded-md border border-border bg-muted px-3 py-2 text-sm font-medium">
+					{currency}
+				</span>
+				<input
+					className="flex-1 rounded-md border border-border bg-background px-3 py-2 text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+					min={settings?.minimum}
+					max={settings?.maximum}
+					step="0.01"
+					type="number"
+					{...form.register(name as any, { valueAsNumber: true })}
+				/>
+			</div>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+const renderFileUpload = (props: TypeformRendererProps, label: string) => {
+	const { form, name, cfg, error } = props;
+	return (
+		<div className="flex flex-col gap-1">
+			<FieldLabel description={cfg.description} label={label} />
+			<input
+				className="rounded-md border border-border bg-background px-3 py-2 text-foreground file:mr-4 file:rounded file:border-0 file:bg-muted file:px-2 file:py-1 file:text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+				multiple
+				type="file"
+				{...form.register(name as any)}
+			/>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+const renderDate = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	return (
+		<div className="flex flex-col gap-1">
+			<FieldLabel description={cfg.description} label={label} />
+			<input
+				className="rounded-md border border-border bg-background px-3 py-2 text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+				type="date"
+				{...form.register(name as any)}
+			/>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+const renderCalendly = (props: TypeformRendererProps) => {
+	const { cfg, label } = props;
+	const url =
+		(cfg.questionSettings?.calendlyUrl as string | undefined) ??
+		"https://calendly.com/";
+	return (
+		<div className="rounded-md border border-dashed border-border bg-muted/20 p-4 text-sm text-muted-foreground">
+			<div className="mb-1 text-xs uppercase tracking-wide text-muted-foreground/80">
+				Calendly
+			</div>
+			<div className="mb-2">{label}</div>
+			<a
+				className="inline-flex items-center gap-2 text-primary underline"
+				href={url}
+				rel="noreferrer"
+				target="_blank"
+			>
+				Schedule via Calendly
+			</a>
+		</div>
+	);
+};
+
+export const otherRenderers: TypeformRendererMap = {
+	number: renderNumber,
+	payment: renderPayment,
+	fileUpload: (props) => renderFileUpload(props, props.label),
+	googleDrive: (props) =>
+		renderFileUpload(props, `${props.label} (Google Drive)`),
+	date: renderDate,
+	calendly: renderCalendly,
+};

--- a/packages/autoform/src/typeform/renderers/scale.tsx
+++ b/packages/autoform/src/typeform/renderers/scale.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+
+import {
+	FieldError,
+	FieldLabel,
+	TypeformRendererMap,
+	TypeformRendererProps,
+} from "./shared";
+
+const renderSlider = (
+	props: TypeformRendererProps,
+	{
+		min,
+		max,
+		step,
+		labels,
+	}: { min: number; max: number; step?: number; labels?: string[] },
+) => {
+	const { form, name, label, cfg, error } = props;
+	const value = form.watch(name as any) ?? min;
+
+	return (
+		<div className="flex flex-col gap-2">
+			<FieldLabel description={cfg.description} label={label} />
+			<div className="flex items-center gap-3">
+				<input
+					className="flex-1"
+					max={max}
+					min={min}
+					step={step ?? 1}
+					type="range"
+					value={value}
+					onChange={(event) => {
+						const next = Number(event.target.value);
+						form.setValue(name as any, next as any, {
+							shouldDirty: true,
+							shouldValidate: true,
+						});
+					}}
+				/>
+				<span className="w-12 text-right text-sm font-medium">{value}</span>
+			</div>
+			{labels && labels.length === 2 ? (
+				<div className="flex justify-between text-xs text-muted-foreground">
+					<span>{labels[0]}</span>
+					<span>{labels[1]}</span>
+				</div>
+			) : null}
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+const renderNps = (props: TypeformRendererProps) => {
+	const labels = cfgLabels(props.cfg) ?? ["Not likely", "Extremely likely"];
+	return renderSlider(props, { min: 0, max: 10, labels });
+};
+
+const cfgLabels = (cfg: TypeformRendererProps["cfg"]) =>
+	(cfg.questionSettings?.npsLabels as string[] | undefined) ?? undefined;
+
+const renderOpinionScale = (props: TypeformRendererProps) => {
+	const min = typeof props.cfg.min === "number" ? props.cfg.min : 0;
+	const max = typeof props.cfg.max === "number" ? props.cfg.max : 10;
+	return renderSlider(props, { min, max });
+};
+
+const renderRating = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	const max = (cfg.questionSettings?.ratingMax as number | undefined) ?? 5;
+	const value = form.watch(name as any) ?? 0;
+	const icon = (cfg.questionSettings?.ratingIcon as string | undefined) ?? "★";
+
+	return (
+		<div className="flex flex-col gap-1">
+			<FieldLabel description={cfg.description} label={label} />
+			<div className="flex gap-1">
+				{Array.from({ length: max }).map((_, index) => {
+					const score = index + 1;
+					const active = value >= score;
+					return (
+						<button
+							key={score}
+							className={`h-10 w-10 rounded-full border text-xl transition focus:outline-none focus:ring-2 focus:ring-primary ${
+								active
+									? "border-primary bg-primary text-primary-foreground"
+									: "border-border bg-background"
+							}`}
+							onClick={(event) => {
+								event.preventDefault();
+								form.setValue(name as any, score as any, {
+									shouldDirty: true,
+									shouldValidate: true,
+								});
+							}}
+							type="button"
+						>
+							{icon}
+						</button>
+					);
+				})}
+			</div>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+export const scaleRenderers: TypeformRendererMap = {
+	nps: renderNps,
+	opinionScale: renderOpinionScale,
+	rating: renderRating,
+};

--- a/packages/autoform/src/typeform/renderers/shared.tsx
+++ b/packages/autoform/src/typeform/renderers/shared.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import type { UseFormReturn } from "react-hook-form";
+import { z } from "zod";
+
+import type { FieldConfig, ChoiceOption } from "../../utils/utils";
+import type { TypeformQuestionType } from "../types";
+
+export type TypeformRendererProps = {
+	name: string;
+	label: string;
+	error?: string;
+	cfg: FieldConfig;
+	form: UseFormReturn<any>;
+	def: z.ZodTypeAny;
+	base: z.ZodTypeAny;
+	questionType?: TypeformQuestionType;
+};
+
+export type TypeformRenderer = (
+	props: TypeformRendererProps,
+) => React.ReactNode | undefined;
+
+export type TypeformRendererMap = Partial<
+	Record<TypeformQuestionType, TypeformRenderer>
+>;
+
+export const FieldError: React.FC<{ message?: string }> = ({ message }) => {
+	if (!message) return null;
+	return (
+		<span className="text-xs text-red-500 dark:text-red-400">{message}</span>
+	);
+};
+
+export const FieldLabel: React.FC<{ label: string; description?: string }> = ({
+	label,
+	description,
+}) => {
+	return (
+		<div className="flex flex-col">
+			<span className="text-sm font-medium text-muted-foreground">{label}</span>
+			{description ? (
+				<span className="text-xs text-muted-foreground/80">{description}</span>
+			) : null}
+		</div>
+	);
+};
+
+export const getOptions = (
+	cfg: FieldConfig,
+	fallback: ChoiceOption[] = [],
+): ChoiceOption[] => {
+	if (cfg.options && cfg.options.length) return cfg.options;
+	return fallback;
+};
+
+export const ensureArray = <T,>(value: T | T[] | undefined): T[] => {
+	if (Array.isArray(value)) return value;
+	if (typeof value === "undefined") return [];
+	return [value];
+};

--- a/packages/autoform/src/typeform/renderers/text.tsx
+++ b/packages/autoform/src/typeform/renderers/text.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+
+import {
+	FieldError,
+	FieldLabel,
+	TypeformRendererMap,
+	TypeformRendererProps,
+} from "./shared";
+
+const renderLongText = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	return (
+		<div className="flex flex-col gap-1">
+			<FieldLabel description={cfg.description} label={label} />
+			<textarea
+				className="min-h-32 rounded-md border border-border bg-background px-3 py-2 text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+				rows={cfg.rows ?? 5}
+				{...form.register(name as any)}
+			/>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+const renderShortText = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	return (
+		<div className="flex flex-col gap-1">
+			<FieldLabel description={cfg.description} label={label} />
+			<input
+				className="rounded-md border border-border bg-background px-3 py-2 text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+				placeholder={cfg.placeholder}
+				type="text"
+				{...form.register(name as any)}
+			/>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+const renderVideo = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	const accept =
+		(cfg.questionSettings?.videoAccept as string | undefined) ?? "video/*";
+	return (
+		<div className="flex flex-col gap-1">
+			<FieldLabel description={cfg.description} label={label} />
+			<input
+				accept={accept}
+				className="rounded-md border border-border bg-background px-3 py-2 text-foreground file:mr-4 file:rounded file:border-0 file:bg-muted file:px-2 file:py-1 file:text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+				type="file"
+				{...form.register(name as any)}
+			/>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+const renderClarifyWithAI = (props: TypeformRendererProps) => {
+	const { form, name, label, cfg, error } = props;
+	const helper =
+		(cfg.questionSettings?.clarifyPrompt as string | undefined) ??
+		"Our AI assistant will ask follow-up questions based on your answer.";
+	return (
+		<div className="flex flex-col gap-2">
+			<FieldLabel description={cfg.description} label={label} />
+			<textarea
+				className="min-h-32 rounded-md border border-border bg-background px-3 py-2 text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+				{...form.register(name as any)}
+			/>
+			<div className="text-xs text-muted-foreground">{helper}</div>
+			<FieldError message={error} />
+		</div>
+	);
+};
+
+const renderStaticBlock = (props: TypeformRendererProps, variant: string) => {
+	const { cfg, label } = props;
+	const content =
+		(cfg.questionSettings?.content as string | undefined) ??
+		cfg.description ??
+		label;
+	return (
+		<div className="rounded-md border border-dashed border-border bg-muted/20 p-4 text-sm text-muted-foreground">
+			<div className="mb-1 text-xs uppercase tracking-wide text-muted-foreground/80">
+				{variant}
+			</div>
+			<div>{content}</div>
+		</div>
+	);
+};
+
+export const textRenderers: TypeformRendererMap = {
+	longText: renderLongText,
+	shortText: renderShortText,
+	video: renderVideo,
+	clarifyWithAI: renderClarifyWithAI,
+	statement: (props) => renderStaticBlock(props, "Statement"),
+	welcomeScreen: (props) => renderStaticBlock(props, "Welcome"),
+	endScreen: (props) => renderStaticBlock(props, "End Screen"),
+	questionGroup: (props) => renderStaticBlock(props, "Group"),
+	multiQuestionPage: (props) => renderStaticBlock(props, "Section"),
+};

--- a/packages/autoform/src/typeform/types.ts
+++ b/packages/autoform/src/typeform/types.ts
@@ -1,0 +1,240 @@
+import { z } from "zod";
+
+import { unwrapType, type FieldConfig } from "../utils/utils";
+
+export type TypeformQuestionType =
+	| "contactInfo"
+	| "email"
+	| "phoneNumber"
+	| "address"
+	| "website"
+	| "multipleChoice"
+	| "dropdown"
+	| "pictureChoice"
+	| "yesNo"
+	| "legal"
+	| "checkbox"
+	| "nps"
+	| "opinionScale"
+	| "rating"
+	| "ranking"
+	| "matrix"
+	| "longText"
+	| "shortText"
+	| "video"
+	| "clarifyWithAI"
+	| "payment"
+	| "number"
+	| "fileUpload"
+	| "googleDrive"
+	| "date"
+	| "calendly"
+	| "questionGroup"
+	| "welcomeScreen"
+	| "statement"
+	| "endScreen"
+	| "multiQuestionPage";
+
+export const TYPEFORM_META_PREFIX = "typeform:";
+
+const descriptionHas = (def: z.ZodTypeAny, needle: string) => {
+	const raw =
+		((def as any)?._def?.description as string | undefined) ??
+		((def as any)?.description as string | undefined);
+	const desc = raw?.toLowerCase?.();
+	return desc ? desc.includes(needle.toLowerCase()) : false;
+};
+
+const getTypeName = (schema: z.ZodTypeAny | undefined): string | undefined => {
+	if (!schema) return undefined;
+	const def = (schema as any)?._def ?? {};
+	return (
+		(def.typeName as string | undefined) ??
+		(def.type as string | undefined) ??
+		((def.schema as any)?._def?.typeName as string | undefined) ??
+		((def.schema as any)?._def?.type as string | undefined) ??
+		undefined
+	);
+};
+
+const normalizeMetaValue = (
+	value: string,
+): TypeformQuestionType | undefined => {
+	const normalized = value
+		.trim()
+		.replace(/[^a-z0-9-]/gi, "")
+		.toLowerCase();
+	const mapping: Record<string, TypeformQuestionType> = {
+		"contact-info": "contactInfo",
+		contactinfo: "contactInfo",
+		email: "email",
+		"phone-number": "phoneNumber",
+		phonenumber: "phoneNumber",
+		address: "address",
+		website: "website",
+		"multiple-choice": "multipleChoice",
+		multiplechoice: "multipleChoice",
+		dropdown: "dropdown",
+		"picture-choice": "pictureChoice",
+		picturechoice: "pictureChoice",
+		"yes-no": "yesNo",
+		yesno: "yesNo",
+		legal: "legal",
+		checkbox: "checkbox",
+		nps: "nps",
+		"opinion-scale": "opinionScale",
+		opinionscale: "opinionScale",
+		rating: "rating",
+		ranking: "ranking",
+		matrix: "matrix",
+		"long-text": "longText",
+		longtext: "longText",
+		"short-text": "shortText",
+		shorttext: "shortText",
+		video: "video",
+		"clarify-with-ai": "clarifyWithAI",
+		clarifywithai: "clarifyWithAI",
+		payment: "payment",
+		number: "number",
+		"file-upload": "fileUpload",
+		fileupload: "fileUpload",
+		"google-drive": "googleDrive",
+		googledrive: "googleDrive",
+		date: "date",
+		calendly: "calendly",
+		"question-group": "questionGroup",
+		questiongroup: "questionGroup",
+		"welcome-screen": "welcomeScreen",
+		welcomescreen: "welcomeScreen",
+		statement: "statement",
+		"end-screen": "endScreen",
+		endscreen: "endScreen",
+		"multi-question-page": "multiQuestionPage",
+		multiquestionpage: "multiQuestionPage",
+	};
+
+	return mapping[normalized];
+};
+
+const parseTypeformMeta = (
+	def: z.ZodTypeAny,
+): TypeformQuestionType | undefined => {
+	const desc =
+		((def as any)?._def?.description as string | undefined) ??
+		((def as any)?.description as string | undefined);
+	if (!desc) return undefined;
+	const match = desc.match(/typeform:([a-z0-9-]+)/i);
+	if (!match) return undefined;
+	return normalizeMetaValue(match[1]);
+};
+
+export const determineQuestionType = (
+	def: z.ZodTypeAny,
+	cfg: FieldConfig,
+	name: string,
+): TypeformQuestionType | undefined => {
+	if (cfg.questionType) return cfg.questionType;
+
+	const metaFromDescription = parseTypeformMeta(def);
+	if (metaFromDescription) return metaFromDescription;
+
+	const base = unwrapType(def);
+	const typeName = getTypeName(base);
+
+	if (!typeName) return undefined;
+
+	if (typeName === "ZodObject" || typeName === "object") {
+		if (
+			descriptionHas(def, "contact info") ||
+			descriptionHas(base, "contact info")
+		) {
+			return "contactInfo";
+		}
+		if (descriptionHas(def, "address")) {
+			return "address";
+		}
+		if (descriptionHas(def, "question group")) {
+			return "questionGroup";
+		}
+	}
+
+	if (typeName === "ZodBoolean" || typeName === "boolean") {
+		if (descriptionHas(def, "legal")) return "legal";
+		if (descriptionHas(def, "consent")) return "checkbox";
+		return "yesNo";
+	}
+
+	if (typeName === "ZodNumber" || typeName === "number") {
+		if (descriptionHas(def, "nps")) return "nps";
+		if (descriptionHas(def, "opinion")) return "opinionScale";
+		if (descriptionHas(def, "rating")) return "rating";
+		return "number";
+	}
+
+	if (typeName === "ZodDate" || typeName === "date") return "date";
+
+	if (typeName === "ZodString" || typeName === "string") {
+		const checks = ((base as any)?._def?.checks ?? []) as Array<{
+			kind: string;
+		}>;
+		if (
+			checks.some(
+				(c) => (c as any)?.kind === "email" || (c as any)?.format === "email",
+			)
+		) {
+			return "email";
+		}
+		if (
+			checks.some(
+				(c) => (c as any)?.kind === "url" || (c as any)?.format === "url",
+			)
+		) {
+			return "website";
+		}
+		if (descriptionHas(def, "phone")) return "phoneNumber";
+		if (descriptionHas(def, "address")) return "address";
+		if (descriptionHas(def, "video")) return "video";
+		if (descriptionHas(def, "clarify")) return "clarifyWithAI";
+		if (cfg.widget === "textarea" || descriptionHas(def, "long text")) {
+			return "longText";
+		}
+		if (descriptionHas(def, "short text")) return "shortText";
+	}
+
+	if (typeName === "ZodArray" || typeName === "array") {
+		const element = unwrapType(
+			((base as any)?._def?.type ?? null) as z.ZodTypeAny,
+		);
+		const elTypeName = getTypeName(element);
+		if (
+			(elTypeName === "ZodObject" || elTypeName === "object") &&
+			cfg.questionSettings?.matrix
+		) {
+			return "matrix";
+		}
+		if (cfg.questionSettings?.ranking) return "ranking";
+		if (cfg.multiple || descriptionHas(def, "multiple choice"))
+			return "multipleChoice";
+		if (elTypeName === "ZodString" || elTypeName === "string")
+			return "multipleChoice";
+	}
+
+	if (cfg.options?.length) {
+		if (cfg.questionSettings?.pictureChoice) return "pictureChoice";
+		if (cfg.multiple) return "multipleChoice";
+		if (cfg.widget === "select") return "dropdown";
+		return "multipleChoice";
+	}
+
+	if (descriptionHas(def, "payment")) return "payment";
+	if (descriptionHas(def, "file upload") || descriptionHas(def, "file"))
+		return "fileUpload";
+	if (descriptionHas(def, "google drive")) return "googleDrive";
+	if (descriptionHas(def, "calendly")) return "calendly";
+	if (descriptionHas(def, "statement")) return "statement";
+	if (descriptionHas(def, "welcome")) return "welcomeScreen";
+	if (descriptionHas(def, "end screen")) return "endScreen";
+	if (descriptionHas(def, "multi-question")) return "multiQuestionPage";
+
+	return undefined;
+};

--- a/packages/autoform/src/utils/utils.ts
+++ b/packages/autoform/src/utils/utils.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import type { TypeformQuestionType } from "../typeform/types";
+
 export type Widget =
 	| "input"
 	| "number"
@@ -11,10 +13,18 @@ export type Widget =
 	| "date"
 	| "date-range";
 
+export type ChoiceOption = {
+	value: string;
+	label: string;
+	description?: string;
+	imageUrl?: string;
+	icon?: string;
+};
+
 export type FieldConfig = {
 	label?: string;
 	widget?: Widget;
-	options?: Array<{ value: string; label: string }>;
+	options?: ChoiceOption[];
 	min?: number;
 	max?: number;
 	step?: number;
@@ -26,6 +36,35 @@ export type FieldConfig = {
 	captionLayout?: "dropdown" | "buttons";
 	fromYear?: number;
 	toYear?: number;
+	description?: string;
+	helperText?: string;
+	questionType?: TypeformQuestionType;
+	questionSettings?: Record<string, unknown> & {
+		legalText?: string;
+		contactFields?: string[];
+		addressFields?: string[];
+		fieldLabels?: Record<string, string>;
+		phonePattern?: string;
+		ratingMax?: number;
+		ratingIcon?: string;
+		npsLabels?: string[];
+		ranking?: { enforceUnique?: boolean };
+		matrix?: {
+			rows: string[];
+			columns: string[];
+			multiSelect?: boolean;
+		};
+		pictureChoice?: boolean;
+		videoAccept?: string;
+		calendlyUrl?: string;
+		payment?: {
+			currency?: string;
+			minimum?: number;
+			maximum?: number;
+		};
+		clarifyPrompt?: string;
+		content?: string;
+	};
 };
 
 export type FieldsConfig<T> = Partial<Record<keyof T & string, FieldConfig>>;


### PR DESCRIPTION
## Summary
- restore the onboarding AutoForm demo so the original email, password, slider, and calendar fields remain visible on the gallery page
- add a dedicated Typeform showcase that exercises the new contact info, rating, consent, and multiple choice renderers while tightening the surrounding copy
- factor out a reusable ResultPreview helper and enrich the manual vs AutoForm comparison cards with JSON summaries

## Testing
- pnpm vitest run packages/autoform/src/typeform/__tests__/question-type.test.ts --environment node
- pnpm lint *(fails: existing lint violations across unrelated API handlers and autoform utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68e6559fc844832991f7ac0232ffeb08