### PR TITLE
Refine agent modal form with HeyGen autoform widgets

### DIFF
--- a/components/Sidebar/AgentModal.tsx
+++ b/components/Sidebar/AgentModal.tsx
@@ -1,14 +1,12 @@
 "use client";
 
-import type { Agent } from "./AgentCard";
-
-import React, { useMemo, useState } from "react";
-import { z } from "zod";
-import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import React, { useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
 
-import AgentPreview from "./AgentPreview";
-
+import { AutoForm } from "@/components/forms/AutoForm";
+import type { FieldConfig, FieldsConfig } from "@/components/forms/utils";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -16,13 +14,48 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
-import { AutoForm } from "@/components/forms/AutoForm";
-import { AgentConfigSchema } from "@/lib/schemas/agent";
 import {
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+	languagesOptions,
+	sttProviderOptions,
+	useAvatarOptionsQuery,
+	useKnowledgeBaseOptionsQuery,
+	useMcpServerOptionsQuery,
+	useVoiceOptionsQuery,
+	voiceChatTransportOptions,
+	voiceEmotionOptions,
+} from "@/data/options";
+import { AgentConfigSchema } from "@/lib/schemas/agent";
+import type { Agent } from "./AgentCard";
+import AgentPreview from "./AgentPreview";
+
+const enabledDisabledOptions = [
+	{ value: "true", label: "Enabled" },
+	{ value: "false", label: "Disabled" },
+];
+
+const rateMultiplierOptions = [
+	{ label: "1x", value: "1" },
+	{ label: "2x", value: "2" },
+	{ label: "3x", value: "3" },
+	{ label: "4x", value: "4" },
+	{ label: "5x", value: "5" },
+];
+
+const videoResolutionOptions = [
+	{ value: "720p", label: "720p" },
+	{ value: "1080p", label: "1080p" },
+];
+
+const videoBackgroundOptions = [
+	{ value: "transparent", label: "Transparent" },
+	{ value: "blur", label: "Blur" },
+	{ value: "none", label: "None" },
+];
 
 export default function AgentModal(props: {
 	mode: "view" | "edit" | "create";
@@ -81,9 +114,16 @@ export default function AgentModal(props: {
 	const isEdit = effectiveMode === "edit";
 	const isCreate = effectiveMode === "create";
 
+	const { data: avatarOptions = [] } = useAvatarOptionsQuery();
+	const { data: voiceOptions = [] } = useVoiceOptionsQuery();
+	const { data: knowledgeBaseOptions = [] } = useKnowledgeBaseOptionsQuery();
+	const { data: mcpServerOptions = [] } = useMcpServerOptionsQuery();
+
 	// Combined schema: full AgentConfig + sidebar-only fields + create-only monetization fields
 	const AgentFormSchema = useMemo(() => {
-		const base = AgentConfigSchema as unknown as z.ZodObject<any>;
+		const base = AgentConfigSchema as unknown as z.ZodObject<
+			Record<string, z.ZodTypeAny>
+		>;
 		return base.extend({
 			role: z.string().optional(),
 			avatarUrl: z.string().url().optional().or(z.literal("")).optional(),
@@ -101,13 +141,13 @@ export default function AgentModal(props: {
 		resolver: zodResolver(AgentFormSchema),
 		mode: "onChange",
 		defaultValues: {
-			id: (working as any)?.id || "new",
-			name: working?.name || "",
-			avatarId: undefined as any,
-			role: working?.role || "",
-			avatarUrl: working?.avatarUrl || "",
-			description: working?.description || "",
-			tags: working?.tags || [],
+			id: working?.id ?? "new",
+			name: working?.name ?? "",
+			avatarId: undefined,
+			role: working?.role ?? "",
+			avatarUrl: working?.avatarUrl ?? "",
+			description: working?.description ?? "",
+			tags: working?.tags ?? [],
 			monetize: false,
 			rateMultiplier: "1",
 		},
@@ -116,13 +156,13 @@ export default function AgentModal(props: {
 	React.useEffect(() => {
 		// Sync form defaults when switching target or mode
 		form.reset({
-			id: (working as any)?.id || "new",
-			name: working?.name || "",
-			avatarId: undefined as any,
-			role: working?.role || "",
-			avatarUrl: working?.avatarUrl || "",
-			description: working?.description || "",
-			tags: working?.tags || [],
+			id: working?.id ?? "new",
+			name: working?.name ?? "",
+			avatarId: undefined,
+			role: working?.role ?? "",
+			avatarUrl: working?.avatarUrl ?? "",
+			description: working?.description ?? "",
+			tags: working?.tags ?? [],
 			monetize: false,
 			rateMultiplier: "1",
 		});
@@ -199,26 +239,183 @@ export default function AgentModal(props: {
 							)}
 							{(() => {
 								const monetize = form.watch("monetize");
-								const fields: any = {
-									name: { label: "Name" },
-									role: { label: "Role" },
-									avatarUrl: { label: "Avatar URL" },
-									description: { label: "Description", widget: "textarea" },
-									tags: { label: "Tags" },
+								const fields: Record<string, FieldConfig> = {
+									name: { label: "Name", placeholder: "Concierge Ava" },
+									role: { label: "Role / Title", placeholder: "AI Concierge" },
+									avatarId: {
+										label: "Avatar",
+										widget: "select",
+										options: avatarOptions,
+										placeholder: "Select avatar",
+									},
+									avatarUrl: {
+										label: "Avatar Override URL",
+										placeholder: "https://...",
+									},
+									voiceId: {
+										label: "Voice",
+										widget: "select",
+										options: voiceOptions,
+										placeholder: "Select voice",
+									},
+									language: {
+										label: "Language",
+										widget: "select",
+										options: languagesOptions,
+										placeholder: "Select language",
+									},
+									model: { label: "Model", placeholder: "gpt-4o-mini" },
+									temperature: {
+										label: "Temperature",
+										widget: "slider",
+										min: 0,
+										max: 2,
+										step: 0.1,
+									},
+									quality: { label: "Avatar Quality" },
+									voiceChatTransport: {
+										label: "Voice Chat Transport",
+										widget: "select",
+										options: voiceChatTransportOptions,
+									},
+									"stt.provider": {
+										label: "STT Provider",
+										widget: "select",
+										options: sttProviderOptions,
+									},
+									"stt.confidenceThreshold": {
+										label: "STT Confidence Threshold",
+										widget: "slider",
+										min: 0,
+										max: 1,
+										step: 0.05,
+									},
+									disableIdleTimeout: {
+										label: "Disable Idle Timeout",
+										widget: "select",
+										options: enabledDisabledOptions,
+									},
+									activityIdleTimeout: {
+										label: "Activity Idle Timeout (sec)",
+										widget: "slider",
+										min: 30,
+										max: 3600,
+										step: 15,
+									},
+									"video.resolution": {
+										label: "Video Resolution",
+										widget: "select",
+										options: videoResolutionOptions,
+									},
+									"video.background": {
+										label: "Video Background",
+										widget: "select",
+										options: videoBackgroundOptions,
+									},
+									"video.fps": {
+										label: "Video FPS",
+										widget: "slider",
+										min: 15,
+										max: 60,
+										step: 1,
+									},
+									"audio.sampleRate": {
+										label: "Audio Sample Rate",
+										widget: "slider",
+										min: 16000,
+										max: 48000,
+										step: 1000,
+									},
+									"audio.noiseSuppression": {
+										label: "Noise Suppression",
+										widget: "select",
+										options: enabledDisabledOptions,
+									},
+									"audio.echoCancellation": {
+										label: "Echo Cancellation",
+										widget: "select",
+										options: enabledDisabledOptions,
+									},
+									"voice.rate": {
+										label: "Voice Rate",
+										widget: "slider",
+										min: 0.5,
+										max: 2,
+										step: 0.1,
+									},
+									"voice.emotion": {
+										label: "Voice Emotion",
+										widget: "select",
+										options: voiceEmotionOptions,
+									},
+									"voice.elevenlabs_settings.stability": {
+										label: "ElevenLabs Stability",
+										widget: "slider",
+										min: 0,
+										max: 1,
+										step: 0.05,
+									},
+									"voice.elevenlabs_settings.similarity_boost": {
+										label: "ElevenLabs Similarity Boost",
+										widget: "slider",
+										min: 0,
+										max: 1,
+										step: 0.05,
+									},
+									"voice.elevenlabs_settings.style": {
+										label: "ElevenLabs Style",
+										widget: "slider",
+										min: 0,
+										max: 1,
+										step: 0.05,
+									},
+									"voice.elevenlabs_settings.model_id": {
+										label: "ElevenLabs Model ID",
+										placeholder: "eleven_monolingual_v2",
+									},
+									"voice.elevenlabs_settings.use_speaker_boost": {
+										label: "ElevenLabs Speaker Boost",
+										widget: "select",
+										options: enabledDisabledOptions,
+									},
+									knowledgeBaseId: {
+										label: "Knowledge Base",
+										widget: "select",
+										options: knowledgeBaseOptions,
+										placeholder: "Select knowledge base",
+									},
+									mcpServers: {
+										label: "MCP Servers",
+										widget: "select",
+										options: mcpServerOptions,
+									},
+									systemPrompt: {
+										label: "System Prompt",
+										widget: "textarea",
+										placeholder: "Guide your agent's behavior...",
+									},
+									description: {
+										label: "Description",
+										widget: "textarea",
+										placeholder: "Visible summary for teammates...",
+									},
+									tags: {
+										label: "Tags",
+										placeholder: "Add tags and press Enter",
+									},
 								};
+
 								if (isCreate) {
-									fields.monetize = { label: "Monetize" };
+									fields.monetize = {
+										label: "Enable Monetization",
+										widget: "select",
+										options: enabledDisabledOptions,
+									};
 									if (monetize) {
 										fields.rateMultiplier = {
-											label: "Multiplier",
+											label: "Rate Multiplier",
 											widget: "select",
-											options: [
-												{ label: "1x", value: "1" },
-												{ label: "2x", value: "2" },
-												{ label: "3x", value: "3" },
-												{ label: "4x", value: "4" },
-												{ label: "5x", value: "5" },
-											],
+											options: rateMultiplierOptions,
 										};
 									}
 								}
@@ -226,8 +423,12 @@ export default function AgentModal(props: {
 									<AutoForm
 										className="space-y-3"
 										schema={AgentFormSchema}
-										form={form as any}
-										fields={fields}
+										form={form}
+										fields={
+											fields as unknown as FieldsConfig<
+												z.infer<typeof AgentFormSchema>
+											>
+										}
 										submitLabel={isCreate ? "Create" : "Save"}
 										onSubmit={(values: z.infer<typeof AgentFormSchema>) => {
 											const name = String(values.name ?? "");
@@ -242,19 +443,11 @@ export default function AgentModal(props: {
 													? String(values.description)
 													: "";
 											const tags: string[] = Array.isArray(values.tags)
-												? (values.tags as string[])
-												: typeof (values as any).tags === "string"
-													? ((values as any).tags as string)
-															.split(",")
-															.map((s: string) => s.trim())
-															.filter(Boolean)
-													: [];
+												? values.tags
+												: [];
 
 											const next: Agent = {
-												id:
-													(values as any)?.id ||
-													working?.id ||
-													`new-${Date.now()}`,
+												id: values.id || working?.id || `new-${Date.now()}`,
 												name,
 												role,
 												avatarUrl,

--- a/components/Sidebar/AgentModal.tsx
+++ b/components/Sidebar/AgentModal.tsx
@@ -5,8 +5,11 @@ import React, { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-import { AutoForm } from "@/components/forms/AutoForm";
-import type { FieldConfig, FieldsConfig } from "@/components/forms/utils";
+import { AutoForm } from "@/components/external/zod-react-form-auto/src/AutoForm";
+import type {
+	FieldConfig,
+	FieldsConfig,
+} from "@/components/external/zod-react-form-auto/src/utils/utils";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -387,6 +390,7 @@ export default function AgentModal(props: {
 									mcpServers: {
 										label: "MCP Servers",
 										widget: "select",
+										multiple: true,
 										options: mcpServerOptions,
 									},
 									systemPrompt: {


### PR DESCRIPTION
## Summary
- replace the agent creation modal field configuration with autoform widgets that match HeyGen-specific options and slider controls
- load dynamic options for avatars, voices, knowledge bases, and MCP servers using the shared data hooks
- streamline form defaults and submission handling to remove `any` casts while preserving existing agent save behaviour

## Testing
- pnpm biome check components/Sidebar/AgentModal.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e731d9457c8329851af779b498c879