### PR TITLE
fix: render nested autoform groups correctly

### DIFF
--- a/components/forms/AutoForm.tsx
+++ b/components/forms/AutoForm.tsx
@@ -110,18 +110,22 @@ export function AutoForm<TSchema extends z.ZodObject<any, any>>({
 		>
 			{keys.map((key) => {
 				const def = shape[key];
+				const baseDef = unwrapType(def as unknown as z.ZodTypeAny) as any;
 
 				if (process.env.NODE_ENV !== "production") {
 					try {
-						console.debug("AutoForm field", key, (def as any)?._def?.typeName);
+						console.debug("AutoForm field", key, {
+							raw: (def as any)?._def?.typeName,
+							base: baseDef?._def?.typeName,
+						});
 					} catch {}
 				}
 				// Support nested object fields by rendering their children with dotted names
-				if ((def as any)?._def?.typeName === "ZodObject") {
+				if (baseDef?._def?.typeName === "ZodObject") {
 					const innerShape: Record<string, z.ZodTypeAny> =
-						typeof (def as any)._def?.shape === "function"
-							? ((def as any)._def.shape() as Record<string, z.ZodTypeAny>)
-							: ((def as any).shape as Record<string, z.ZodTypeAny>);
+						typeof baseDef._def?.shape === "function"
+							? ((baseDef as any)._def.shape() as Record<string, z.ZodTypeAny>)
+							: ((baseDef as any).shape as Record<string, z.ZodTypeAny>);
 
 					return (
 						<fieldset key={key} className="rounded-md border border-border p-2">


### PR DESCRIPTION
## Summary
- rebuild the agent modal form around the shared AutoForm utilities and HeyGen-specific defaults
- add comprehensive field metadata, dynamic option loading, and monetization handling so controls render as selects, sliders, and text areas instead of plain inputs
- switch to the reusable useZodForm helper with richer default values to keep the form in sync across view, edit, and create modes
- ensure AutoForm unwraps optional nested objects so grouped video, audio, and voice controls render their configured widgets instead of `[object Object]`

## Testing
- pnpm lint *(fails: existing repo-wide lint warnings about import type usage and explicit `any` in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68e738a358148329b28d740142008b29