### PR TITLE
Fix AutoForm select normalization for nested agent fields

### DIFF
--- a/components/forms/AutoField.tsx
+++ b/components/forms/AutoField.tsx
@@ -37,13 +37,127 @@ export type AutoFieldProps = {
 	fields?: FieldsConfig<any>;
 };
 
+const SELECT_VALUE_KEYS = ["value", "id", "key", "name"] as const;
+
+function coerceSelectValue(raw: unknown): string | undefined {
+	if (raw == null) return undefined;
+	if (typeof raw === "string") return raw;
+	if (typeof raw === "number" || typeof raw === "boolean") {
+		return String(raw);
+	}
+	if (typeof raw === "object") {
+		for (const key of SELECT_VALUE_KEYS) {
+			const candidate = (raw as Record<string, unknown>)[key];
+			if (
+				typeof candidate === "string" ||
+				typeof candidate === "number" ||
+				typeof candidate === "boolean"
+			) {
+				const str = String(candidate);
+				if (str.length > 0) return str;
+			}
+		}
+	}
+
+	return undefined;
+}
+
+function coerceSelectArray(raw: unknown): string[] {
+	if (Array.isArray(raw)) {
+		return raw
+			.map((entry) => coerceSelectValue(entry))
+			.filter(
+				(value): value is string =>
+					typeof value === "string" && value.length > 0,
+			);
+	}
+
+	const single = coerceSelectValue(raw);
+	return single ? [single] : [];
+}
+
+function arraysShallowEqual(a: string[], b: string[]) {
+	if (a.length !== b.length) return false;
+	return a.every((value, index) => value === b[index]);
+}
+
+function useNormalizeSelectValue(
+	form: UseFormReturn<any>,
+	name: string,
+	multiple: boolean,
+	enabled: boolean,
+) {
+	React.useEffect(() => {
+		if (!enabled) return;
+
+		const current = form.getValues(name as any);
+
+		if (multiple) {
+			const normalized = coerceSelectArray(current);
+			const isStringArray =
+				Array.isArray(current) &&
+				current.every((item) => typeof item === "string");
+
+			if (
+				isStringArray &&
+				arraysShallowEqual(current as string[], normalized)
+			) {
+				return;
+			}
+
+			if (
+				normalized.length === 0 &&
+				(current == null || (Array.isArray(current) && current.length === 0))
+			) {
+				return;
+			}
+
+			form.setValue(name as any, normalized as any, {
+				shouldDirty: false,
+				shouldTouch: false,
+				shouldValidate: false,
+			});
+			return;
+		}
+
+		const normalized = coerceSelectValue(current);
+		const isPrimitive =
+			typeof current === "string" ||
+			typeof current === "number" ||
+			typeof current === "boolean";
+
+		if (normalized == null) {
+			if (current == null || current === "") {
+				return;
+			}
+
+			form.setValue(name as any, undefined, {
+				shouldDirty: false,
+				shouldTouch: false,
+				shouldValidate: false,
+			});
+			return;
+		}
+
+		if (isPrimitive && String(current) === normalized) {
+			return;
+		}
+
+		form.setValue(name as any, normalized as any, {
+			shouldDirty: false,
+			shouldTouch: false,
+			shouldValidate: false,
+		});
+	}, [enabled, form, multiple, name]);
+}
+
 export const AutoField: React.FC<AutoFieldProps> = ({
 	name,
 	def,
 	form,
 	fields = {},
 }) => {
-	const { register, formState, setValue, getValues } = form;
+	const { register, formState, setValue } = form;
 
 	const cfg = (fields as any)[name] || {};
 	const label = cfg.label ?? name;
@@ -63,17 +177,23 @@ export const AutoField: React.FC<AutoFieldProps> = ({
 	const renderSelect = (
 		opts: Array<{ value: string; label: string }>,
 		multiple = false,
+		placeholderText?: string,
 	) => {
+		const registration = register(name as any);
+
 		if (multiple) {
-			const current = (getValues() as any)[name] ?? [];
+			const normalized = coerceSelectArray(form.watch(name as any));
 
 			return (
 				<div className="flex flex-col gap-1">
 					<span className="text-sm text-muted-foreground">{label}</span>
 					<select
 						multiple
+						name={registration.name}
+						ref={registration.ref}
+						onBlur={registration.onBlur}
 						className="rounded-md border border-border bg-background px-3 py-2 text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
-						value={current as string[]}
+						value={normalized}
 						onChange={(e) => {
 							const selected = Array.from(e.target.selectedOptions).map(
 								(o) => o.value,
@@ -100,16 +220,30 @@ export const AutoField: React.FC<AutoFieldProps> = ({
 			);
 		}
 
+		const normalized = coerceSelectValue(form.watch(name as any)) ?? "";
+		const placeholder = placeholderText ?? `Select ${label}`;
+
 		return (
 			<div className="flex flex-col gap-1">
 				<span className="text-sm text-muted-foreground">{label}</span>
 				<select
+					name={registration.name}
+					ref={registration.ref}
+					onBlur={registration.onBlur}
 					className="rounded-md border border-border bg-background px-3 py-2 text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
-					defaultValue=""
-					{...register(name as any)}
+					value={normalized}
+					onChange={(e) => {
+						const next = e.target.value;
+						const payload = next === "" ? undefined : next;
+
+						setValue(name as any, payload as any, {
+							shouldValidate: true,
+							shouldDirty: true,
+						});
+					}}
 				>
 					<option disabled value="">
-						Select {label}
+						{placeholder}
 					</option>
 					{opts.map((o) => (
 						<option key={o.value} value={o.value}>
@@ -126,15 +260,134 @@ export const AutoField: React.FC<AutoFieldProps> = ({
 		);
 	};
 
-	// If the fields config explicitly requests a widget, honor it first
-	if ((cfg as any).widget === "select") {
-		const opts = ((cfg as any).options ?? []) as Array<{
+	const base = unwrapType(def);
+	const baseTypeName = (base as any)?._def?.typeName as string | undefined;
+
+	const configuredSelect = (cfg as any).widget === "select";
+	const configuredOptions = ((cfg as any).options ?? []) as Array<{
+		value: string;
+		label: string;
+	}>;
+	const configuredMultiple = Boolean((cfg as any).multiple);
+	const configuredPlaceholder = (cfg as any).placeholder as string | undefined;
+
+	const unionStringValues = React.useMemo(() => {
+		if (baseTypeName !== "ZodUnion") return null;
+		const options: z.ZodTypeAny[] = (base as any)._def?.options ?? [];
+		const stringVals: string[] = [];
+
+		for (const opt of options) {
+			if ((opt as any)?._def?.typeName === "ZodEnum") {
+				const raw = (opt as any).options;
+				const vals: unknown[] = Array.isArray(raw)
+					? raw
+					: Object.values(raw ?? {});
+
+				for (const v of vals) if (typeof v === "string") stringVals.push(v);
+			} else if ((opt as any)._def?.typeName === "ZodNativeEnum") {
+				const enumObj = (opt as any).enum as Record<string, string | number>;
+
+				for (const v of Object.values(enumObj))
+					if (typeof v === "string") stringVals.push(v);
+			} else if ((opt as any)._def?.typeName === "ZodLiteral") {
+				const litVal = (opt as any)._def?.value;
+
+				if (typeof litVal === "string") stringVals.push(litVal);
+			}
+		}
+
+		if (stringVals.length === 0) return null;
+		return Array.from(new Set(stringVals));
+	}, [base, baseTypeName]);
+
+	const arrayElement =
+		baseTypeName === "ZodArray"
+			? ((base as any)._def?.type as z.ZodTypeAny | undefined)
+			: undefined;
+	const arrayElementTypeName = (arrayElement as any)?._def?.typeName as
+		| string
+		| undefined;
+
+	const enumValues = React.useMemo(() => {
+		if (baseTypeName !== "ZodEnum") return null;
+		return enumStringValuesFromZodEnum((base as any).options);
+	}, [base, baseTypeName]);
+
+	const nativeEnumValues = React.useMemo(() => {
+		if (baseTypeName !== "ZodNativeEnum") return null;
+		const enumObj = (base as any).enum as Record<string, string | number>;
+		return Object.values(enumObj).filter(
+			(v): v is string => typeof v === "string",
+		);
+	}, [base, baseTypeName]);
+
+	const arrayEnumValues = React.useMemo(() => {
+		if (arrayElementTypeName !== "ZodEnum") return null;
+		return enumStringValuesFromZodEnum((arrayElement as any).options);
+	}, [arrayElement, arrayElementTypeName]);
+
+	const arrayNativeEnumValues = React.useMemo(() => {
+		if (arrayElementTypeName !== "ZodNativeEnum") return null;
+		const enumObj = (arrayElement as any).enum as Record<
+			string,
+			string | number
+		>;
+		return Object.values(enumObj).filter(
+			(v): v is string => typeof v === "string",
+		);
+	}, [arrayElement, arrayElementTypeName]);
+
+	const arrayStringSelectOptions = React.useMemo(() => {
+		if (arrayElementTypeName !== "ZodString") return null;
+		if (!(cfg as any).options?.length) return null;
+		return ((cfg as any).options ?? []) as Array<{
 			value: string;
 			label: string;
 		}>;
-		return (function renderConfiguredSelect() {
-			return renderSelect(opts, Boolean((cfg as any).multiple));
-		})();
+	}, [arrayElementTypeName, cfg]);
+
+	const selectNormalization = React.useMemo(
+		() => ({
+			enabled:
+				configuredSelect ||
+				Boolean(enumValues) ||
+				Boolean(nativeEnumValues) ||
+				Boolean(unionStringValues) ||
+				Boolean(arrayEnumValues) ||
+				Boolean(arrayNativeEnumValues) ||
+				Boolean(arrayStringSelectOptions),
+			multiple: configuredSelect
+				? configuredMultiple
+				: arrayEnumValues || arrayNativeEnumValues || arrayStringSelectOptions
+					? true
+					: Boolean(configuredMultiple),
+		}),
+		[
+			arrayEnumValues,
+			arrayNativeEnumValues,
+			arrayStringSelectOptions,
+			configuredMultiple,
+			configuredSelect,
+			enumValues,
+			nativeEnumValues,
+			unionStringValues,
+		],
+	);
+
+	useNormalizeSelectValue(
+		form,
+		name,
+		selectNormalization.multiple,
+		selectNormalization.enabled,
+	);
+
+	// If the fields config explicitly requests a widget, honor it first
+	if (configuredSelect) {
+		return renderSelect(
+			configuredOptions,
+			configuredMultiple,
+			configuredPlaceholder,
+		);
 	}
 	if ((cfg as any).widget === "textarea") {
 		return (
@@ -188,8 +441,6 @@ export const AutoField: React.FC<AutoFieldProps> = ({
 		);
 	}
 
-	const base = unwrapType(def);
-
 	// Dev-only structured debug helper
 	const devLog = (
 		label: string,
@@ -212,95 +463,55 @@ export const AutoField: React.FC<AutoFieldProps> = ({
 	}
 
 	// Enum
-	if ((base as any)?._def?.typeName === "ZodEnum") {
-		const values = enumStringValuesFromZodEnum((base as any).options);
-		const opts = optionsFromStrings(values);
+	if (enumValues) {
+		const opts = optionsFromStrings(enumValues);
 
-		return renderSelect(opts, Boolean((cfg as any).multiple));
+		return renderSelect(opts, configuredMultiple);
 	}
 
 	// Union of enums/strings/literals -> select
-	if ((base as any)._def?.typeName === "ZodUnion") {
-		const options: z.ZodTypeAny[] = (base as any)._def?.options ?? [];
-		const stringVals: string[] = [];
+	if (unionStringValues) {
+		const opts = unionStringValues.map((v) => ({ value: v, label: v }));
 
-		for (const opt of options) {
-			if ((opt as any)?._def?.typeName === "ZodEnum") {
-				const raw = (opt as any).options;
-				const vals: unknown[] = Array.isArray(raw)
-					? raw
-					: Object.values(raw ?? {});
-
-				for (const v of vals) if (typeof v === "string") stringVals.push(v);
-			} else if ((opt as any)._def?.typeName === "ZodNativeEnum") {
-				const enumObj = (opt as any).enum as Record<string, string | number>;
-
-				for (const v of Object.values(enumObj))
-					if (typeof v === "string") stringVals.push(v);
-			} else if ((opt as any)._def?.typeName === "ZodLiteral") {
-				const litVal = (opt as any)._def?.value;
-
-				if (typeof litVal === "string") stringVals.push(litVal);
-			}
-		}
-		if (stringVals.length) {
-			const opts = Array.from(new Set(stringVals)).map((v) => ({
-				value: v,
-				label: v,
-			}));
-
-			return renderSelect(opts, Boolean((cfg as any).multiple));
-		}
+		return renderSelect(opts, configuredMultiple);
 	}
 
 	// Native enum
-	if ((base as any)._def?.typeName === "ZodNativeEnum") {
-		const enumObj = (base as any).enum as Record<string, string | number>;
-		const values = Object.values(enumObj).filter(
-			(v): v is string => typeof v === "string",
-		);
-		const opts = optionsFromStrings(values);
+	if (nativeEnumValues) {
+		const opts = optionsFromStrings(nativeEnumValues);
 
-		return renderSelect(opts, Boolean((cfg as any).multiple));
+		return renderSelect(opts, configuredMultiple);
 	}
 
 	// Array -> multi select or textarea/chips
-	if ((base as any)._def?.typeName === "ZodArray") {
-		const el = (base as any)._def.type as z.ZodTypeAny;
+	if (baseTypeName === "ZodArray") {
+		const el = arrayElement as z.ZodTypeAny;
 		devLog("array:detected", {
 			elType: (el as any)?._def?.typeName,
 			cfgHasOptions: Boolean((cfg as any).options?.length),
 		});
 
-		if ((el as any)?._def?.typeName === "ZodEnum") {
-			const values = enumStringValuesFromZodEnum((el as any).options);
-			const opts = optionsFromStrings(values);
+		if (arrayEnumValues) {
+			const opts = optionsFromStrings(arrayEnumValues);
 			devLog("array:enum -> multi-select", { optionCount: opts.length });
 			return renderSelect(opts, true);
 		}
-		if ((el as any)._def?.typeName === "ZodNativeEnum") {
-			const enumObj = (el as any).enum as Record<string, string | number>;
-			const values = Object.values(enumObj).filter(
-				(v): v is string => typeof v === "string",
-			);
-			const opts = optionsFromStrings(values);
+		if (arrayNativeEnumValues) {
+			const opts = optionsFromStrings(arrayNativeEnumValues);
 			devLog("array:native-enum -> multi-select", { optionCount: opts.length });
 			return renderSelect(opts, true);
 		}
-		if (
-			(el as any)._def?.typeName === "ZodString" &&
-			(cfg as any).options?.length
-		) {
+		if (arrayStringSelectOptions) {
 			devLog("array:string + cfg.options -> multi-select", {
-				optionCount: (cfg as any).options.length,
+				optionCount: arrayStringSelectOptions.length,
 			});
-			return renderSelect((cfg as any).options!, true);
+			return renderSelect(arrayStringSelectOptions, true);
 		}
 		if ((el as any)._def?.typeName === "ZodString") {
 			devLog("array:string -> textarea", {
 				reason: "no options provided; falling back to newline textarea",
 			});
-			const current = (getValues() as any)[name] as string[] | undefined;
+			const current = form.watch(name as any) as string[] | undefined;
 			const defaultValue = Array.isArray(current) ? current.join("\n") : "";
 
 			return (

--- a/components/forms/AutoForm.tsx
+++ b/components/forms/AutoForm.tsx
@@ -122,6 +122,10 @@ export function AutoForm<TSchema extends z.ZodObject<any, any>>({
 				}
 				// Support nested object fields by rendering their children with dotted names
 				if (baseDef?._def?.typeName === "ZodObject") {
+					const groupCfg = (fields as any)?.[key] as
+						| { label?: string }
+						| undefined;
+					const legendLabel = groupCfg?.label ?? key;
 					const innerShape: Record<string, z.ZodTypeAny> =
 						typeof baseDef._def?.shape === "function"
 							? ((baseDef as any)._def.shape() as Record<string, z.ZodTypeAny>)
@@ -130,7 +134,7 @@ export function AutoForm<TSchema extends z.ZodObject<any, any>>({
 					return (
 						<fieldset key={key} className="rounded-md border border-border p-2">
 							<legend className="px-1 text-xs uppercase tracking-wide text-muted-foreground">
-								{key}
+								{legendLabel}
 							</legend>
 							<div className="space-y-2">
 								{Object.keys(innerShape).map((childKey) => {

--- a/components/forms/__tests__/AutoField.test.tsx
+++ b/components/forms/__tests__/AutoField.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import type { UseFormReturn } from "react-hook-form";
+import { useForm } from "react-hook-form";
+import React from "react";
+import { z } from "zod";
+
+import { AutoField } from "../AutoField";
+import type { FieldConfig } from "../utils";
+
+const videoOptions = [
+	{ value: "720p", label: "720p" },
+	{ value: "1080p", label: "1080p" },
+];
+
+const outputOptions = [
+	{ value: "stereo", label: "Stereo" },
+	{ value: "mono", label: "Mono" },
+];
+
+type HarnessProps = {
+	name: string;
+	def: z.ZodTypeAny;
+	defaultValue: unknown;
+	fieldConfig: FieldConfig;
+	onReady?: (form: UseFormReturn<Record<string, unknown>>) => void;
+};
+
+function FieldHarness({
+	name,
+	def,
+	defaultValue,
+	fieldConfig,
+	onReady,
+}: HarnessProps) {
+	const form = useForm<Record<string, unknown>>({
+		defaultValues: {
+			[name]: defaultValue,
+		},
+	});
+
+	React.useEffect(() => {
+		onReady?.(form);
+	}, [form, onReady]);
+
+	return (
+		<form>
+			<AutoField
+				name={name}
+				def={def}
+				form={form as UseFormReturn<any>}
+				fields={{ [name]: fieldConfig }}
+			/>
+		</form>
+	);
+}
+
+describe("AutoField select normalization", () => {
+	it("normalizes object default values for single selects", async () => {
+		let formRef: UseFormReturn<Record<string, unknown>> | null = null;
+
+		const { container } = render(
+			<FieldHarness
+				name="video.resolution"
+				def={z.enum(["720p", "1080p"])}
+				defaultValue={{ value: "1080p", label: "Full HD" }}
+				fieldConfig={{ widget: "select", options: videoOptions }}
+				onReady={(form) => {
+					formRef = form;
+				}}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(formRef).not.toBeNull();
+		});
+
+		await waitFor(() => {
+			const select = container.querySelector(
+				'select[name="video.resolution"]',
+			) as HTMLSelectElement | null;
+			expect(select).not.toBeNull();
+			expect(select!.value).toBe("1080p");
+		});
+
+		expect(() => screen.getByDisplayValue("[object Object]")).toThrow();
+
+		await waitFor(() => {
+			expect(formRef?.getValues("video.resolution")).toBe("1080p");
+		});
+	});
+
+	it("normalizes option objects for multi-select fields", async () => {
+		let formRef: UseFormReturn<Record<string, unknown>> | null = null;
+
+		const { container } = render(
+			<FieldHarness
+				name="audio.outputs"
+				def={z.array(z.string())}
+				defaultValue={[{ value: "stereo", label: "Stereo" }]}
+				fieldConfig={{
+					widget: "select",
+					multiple: true,
+					options: outputOptions,
+				}}
+				onReady={(form) => {
+					formRef = form;
+				}}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(formRef).not.toBeNull();
+		});
+
+		await waitFor(() => {
+			const select = container.querySelector(
+				'select[name="audio.outputs"]',
+			) as HTMLSelectElement | null;
+			expect(select).not.toBeNull();
+			const selected = Array.from(select!.selectedOptions).map(
+				(option) => option.value,
+			);
+			expect(selected).toEqual(["stereo"]);
+		});
+
+		await waitFor(() => {
+			expect(formRef?.getValues("audio.outputs")).toEqual(["stereo"]);
+		});
+	});
+});

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.2.0",
+		"@testing-library/react": "^16.3.0",
 		"@types/dotenv": "^8.2.3",
 		"@types/node": "20.5.7",
 		"@types/react": "^19.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.2.0
         version: 2.2.0
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/dotenv':
         specifier: ^8.2.3
         version: 8.2.3
@@ -297,6 +300,10 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -1796,8 +1803,30 @@ packages:
   '@tanstack/virtual-core@3.13.12':
     resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.0':
+    resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tweenjs/tween.js@25.0.0':
     resolution: {integrity: sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -2087,6 +2116,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
@@ -2104,6 +2137,9 @@ packages:
   aria-hidden@1.2.4:
     resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -2572,6 +2608,9 @@ packages:
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dompurify@3.2.6:
     resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
@@ -3151,6 +3190,10 @@ packages:
     resolution: {integrity: sha512-VVISr+VF2krO91FeuCrm1rSOLACQUYVy7NQkzrOty52Y8TlTPcXcMdQFj9bYzBgXbWCiywlwSZ3Z8u6a+6bMlg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -3740,6 +3783,10 @@ packages:
   preact@10.27.0:
     resolution: {integrity: sha512-/DTYoB6mwwgPytiqQTh/7SFRL98ZdiD8Sk8zIUVOxtwq4oWcwrcd1uno9fE/zZmUaUrFNYzbH14CPebOz9tZQw==}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3810,6 +3857,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -4717,6 +4767,12 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@babel/code-frame@7.27.1':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.27.1
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -6089,7 +6145,30 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.12': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.26.0
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@testing-library/dom': 10.4.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.0.1
+      '@types/react-dom': 19.1.2(@types/react@19.0.1)
+
   '@tweenjs/tween.js@25.0.0': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.2':
     dependencies:
@@ -6428,6 +6507,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.1: {}
 
   any-promise@1.3.0: {}
@@ -6442,6 +6523,10 @@ snapshots:
   aria-hidden@1.2.4:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   assertion-error@2.0.1: {}
 
@@ -6917,6 +7002,8 @@ snapshots:
   diff@5.2.0: {}
 
   dlv@1.1.3: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dompurify@3.2.6:
     optionalDependencies:
@@ -7551,6 +7638,8 @@ snapshots:
   lucide-react@0.539.0(react@19.1.0):
     dependencies:
       react: 19.1.0
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.17:
     dependencies:
@@ -8444,6 +8533,12 @@ snapshots:
 
   preact@10.27.0: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -8520,6 +8615,8 @@ snapshots:
       react: 19.1.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -8,6 +8,8 @@ const sdkSrc = path.resolve(rootDir, "packages/grok-sdk/src");
 export default defineConfig({
 	resolve: {
 		alias: [
+			{ find: /^@$/, replacement: path.join(rootDir) },
+			{ find: /^@\/(.*)$/, replacement: path.join(rootDir, "$1") },
 			{ find: /^grok-sdk$/, replacement: path.join(sdkSrc, "index.ts") },
 			{ find: /^grok-sdk\/(.*)$/, replacement: path.join(sdkSrc, "$1") },
 		],


### PR DESCRIPTION
## Summary
- normalize AutoField select handling so nested agent fields render and persist primitive values instead of `[object Object]`
- respect configured legend labels for nested groups in `AutoForm`
- add targeted regression tests and testing aliases/dependencies for the AutoField select normalization

## Testing
- pnpm exec vitest run components/forms/__tests__/AutoField.test.tsx --config vitest.config.mts --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68e7a0edcbc483298eee8ec8db286269