### PR TITLE
Fix agent modal dropdown values and monetization UX

### DIFF
--- a/components/Sidebar/AgentCard.tsx
+++ b/components/Sidebar/AgentCard.tsx
@@ -3,6 +3,16 @@
 import { Eye, Star, StarOff, X } from "lucide-react";
 import React from "react";
 
+export type AgentMonetizationSummary = {
+	baseRate: number;
+	usagePerMonth: number;
+	usageLabel: string;
+	multiplier: number;
+	projectedMonthly: number;
+	currency: string;
+	profileLabel: string;
+};
+
 export type Agent = {
 	id: string;
 	name: string;
@@ -11,6 +21,9 @@ export type Agent = {
 	description?: string;
 	tags?: string[];
 	isOwnedByUser?: boolean;
+	monetize?: boolean;
+	rateMultiplier?: number;
+	monetizationSummary?: AgentMonetizationSummary;
 };
 
 export default function AgentCard(props: {

--- a/components/forms/utils.ts
+++ b/components/forms/utils.ts
@@ -19,6 +19,7 @@ export type FieldConfig = {
 	multiple?: boolean;
 	rows?: number;
 	placeholder?: string;
+	disabled?: boolean;
 };
 
 export type FieldsConfig<T> = Partial<Record<keyof T & string, FieldConfig>>;

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import * as React from "react";
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+
+import { cn } from "@/lib/utils";
+
+export interface SwitchProps
+	extends React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> {}
+
+export const Switch = React.forwardRef<
+	React.ElementRef<typeof SwitchPrimitives.Root>,
+	SwitchProps
+>(({ className, ...props }, ref) => {
+	return (
+		<SwitchPrimitives.Root
+			ref={ref}
+			className={cn(
+				"peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
+				"data-[state=checked]:bg-primary data-[state=unchecked]:bg-muted",
+				className,
+			)}
+			{...props}
+		>
+			<SwitchPrimitives.Thumb
+				className={cn(
+					"pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform",
+					"data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+				)}
+			/>
+		</SwitchPrimitives.Root>
+	);
+});
+Switch.displayName = SwitchPrimitives.Root.displayName;


### PR DESCRIPTION
## Summary
- add a reusable Radix switch and extend the auto form controls to support switch widgets and disabled select states so dropdowns render labels instead of `[object Object]`
- normalize agent modal defaults, introduce monetization presets, and display a live revenue preview tied to the monetization toggle and multiplier
- extend the sidebar agent type with monetization metadata for downstream consumers

## Testing
- pnpm typecheck *(fails: pre-existing TypeScript errors in unrelated API modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e864294c388329b452c0e86693a166